### PR TITLE
Move background modes guard to location manager wrapper

### DIFF
--- a/MapboxMobileEvents/MMECLLocationManagerWrapper.h
+++ b/MapboxMobileEvents/MMECLLocationManagerWrapper.h
@@ -11,6 +11,7 @@
 @property (nonatomic) CLLocationAccuracy desiredAccuracy;
 @property (nonatomic) CLLocationDistance distanceFilter;
 @property (nonatomic, copy, readonly) NSSet<__kindof CLRegion *> *monitoredRegions;
+@property (nonatomic) BOOL hostAppHasBackgroundCapability;
 
 - (CLAuthorizationStatus)authorizationStatus;
 - (void)startUpdatingLocation;

--- a/MapboxMobileEvents/MMECLLocationManagerWrapper.m
+++ b/MapboxMobileEvents/MMECLLocationManagerWrapper.m
@@ -58,7 +58,7 @@
 
 - (BOOL)allowsBackgroundLocationUpdates {
     if ([self.locationManager respondsToSelector:@selector(allowsBackgroundLocationUpdates)]) {
-        return !self.hostAppHasBackgroundCapability ?: self.locationManager.allowsBackgroundLocationUpdates;
+        return !self.hostAppHasBackgroundCapability ? NO : self.locationManager.allowsBackgroundLocationUpdates;
     }
     return NO;
 }

--- a/MapboxMobileEvents/MMECLLocationManagerWrapper.m
+++ b/MapboxMobileEvents/MMECLLocationManagerWrapper.m
@@ -8,11 +8,15 @@
 
 @implementation MMECLLocationManagerWrapper
 
+@synthesize hostAppHasBackgroundCapability;
+
 - (instancetype)init {
     self = [super init];
     if (self) {
         _locationManager = [[CLLocationManager alloc] init];
         _locationManager.delegate = self;
+        NSArray *backgroundModes = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIBackgroundModes"];
+        self.hostAppHasBackgroundCapability = [backgroundModes containsObject:@"location"];
     }
     return self;
 }
@@ -46,14 +50,15 @@
 }
 
 - (void)setAllowsBackgroundLocationUpdates:(BOOL)allowsBackgroundLocationUpdates {
-    if ([self.locationManager respondsToSelector:@selector(allowsBackgroundLocationUpdates)]) {
+    if ([self.locationManager respondsToSelector:@selector(allowsBackgroundLocationUpdates)]
+        && self.hostAppHasBackgroundCapability) {
         self.locationManager.allowsBackgroundLocationUpdates = allowsBackgroundLocationUpdates;
     }
 }
 
 - (BOOL)allowsBackgroundLocationUpdates {
     if ([self.locationManager respondsToSelector:@selector(allowsBackgroundLocationUpdates)]) {
-        return self.locationManager.allowsBackgroundLocationUpdates;
+        return !self.hostAppHasBackgroundCapability ?: self.locationManager.allowsBackgroundLocationUpdates;
     }
     return NO;
 }

--- a/MapboxMobileEvents/MMELocationManager.m
+++ b/MapboxMobileEvents/MMELocationManager.m
@@ -14,7 +14,6 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
 
 @property (nonatomic) id<MMEUIApplicationWrapper> application;
 @property (nonatomic) id<MMECLLocationManagerWrapper> locationManager;
-@property (nonatomic) BOOL hostAppHasBackgroundCapability;
 @property (nonatomic, getter=isUpdatingLocation, readwrite) BOOL updatingLocation;
 @property (nonatomic) NSDate *backgroundLocationServiceTimeoutAllowedDate;
 @property (nonatomic) NSTimer *backgroundLocationServiceTimeoutTimer;
@@ -26,10 +25,7 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
 - (instancetype)init {
     self = [super init];
     if (self) {
-        NSArray *backgroundModes = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIBackgroundModes"];
-        _hostAppHasBackgroundCapability = [backgroundModes containsObject:@"location"];
-        _application = [[MMEUIApplicationWrapper alloc] init];
-    }
+        _application = [[MMEUIApplicationWrapper alloc] init];    }
     return self;
 }
 
@@ -89,7 +85,7 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
 
         // If the host app can run in the background with `always` location permissions then allow background
         // updates and start the significant location change service and background timeout timer
-        if (self.hostAppHasBackgroundCapability && authorizedAlways) {
+        if (authorizedAlways) {
             [self.locationManager startMonitoringSignificantLocationChanges];
             [self startBackgroundTimeoutTimer];
             self.locationManager.allowsBackgroundLocationUpdates = YES;

--- a/MapboxMobileEvents/MMELocationManager.m
+++ b/MapboxMobileEvents/MMELocationManager.m
@@ -25,7 +25,8 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
 - (instancetype)init {
     self = [super init];
     if (self) {
-        _application = [[MMEUIApplicationWrapper alloc] init];    }
+        _application = [[MMEUIApplicationWrapper alloc] init];        
+    }
     return self;
 }
 
@@ -85,7 +86,7 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
 
         // If the host app can run in the background with `always` location permissions then allow background
         // updates and start the significant location change service and background timeout timer
-        if (authorizedAlways) {
+        if (authorizedAlways && self.locationManager.hostAppHasBackgroundCapability) {
             [self.locationManager startMonitoringSignificantLocationChanges];
             [self startBackgroundTimeoutTimer];
             self.locationManager.allowsBackgroundLocationUpdates = YES;

--- a/MapboxMobileEventsTests/MMECLLocationManagerWrapperFake.m
+++ b/MapboxMobileEventsTests/MMECLLocationManagerWrapperFake.m
@@ -6,6 +6,7 @@
 @synthesize desiredAccuracy;
 @synthesize distanceFilter;
 @synthesize monitoredRegions;
+@synthesize hostAppHasBackgroundCapability;
 
 - (CLAuthorizationStatus)authorizationStatus {
     return self.stub_authorizationStatus;


### PR DESCRIPTION
The `allowsBackgroundLocationUpdates` API is not safe to use unless the host application has set location as a background mode. This guard was in place but was done at the level above where it should have been.

This change moves the guard to the MMECLLocationManagerWrapper that actually holds the real CLLocationManager instance. As the source of truth for all location manager instance interactions, it is the safest place to perform this check.

This avoids a crasher that could occur if the host app received only `in use` permissions from the user and did not have the `location` background mode in the app's plist and the client of this library set the `isMetricsEnabledForInUsePermissions` to `true` (a `false` value did not trigger the crash since setting CLLocationManager's `allowsBackgroundLocationUpdates` property to `false` (the default value) is not a "programmer error".

Subsumes https://github.com/mapbox/mapbox-events-ios/pull/10