### PR TITLE
Move test dependency to Cartfile.private

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "pivotal/Cedar" ~> 1.0
+

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,0 +1,1 @@
+github "pivotal/Cedar" ~> 1.0


### PR DESCRIPTION
Cedar is only needed for testing this project so it should reside in Cartfile.private to avoid building Cedar in all apps making use of this library through Carthage.

@boundsj 👀 