### PR TITLE
Re-introduce visit collection and events

### DIFF
--- a/MapboxMobileEvents/MMEConstants.h
+++ b/MapboxMobileEvents/MMEConstants.h
@@ -26,6 +26,7 @@ extern NSString * const MMEEventTypeMapLoad;
 extern NSString * const MMEEventTypeMapTap;
 extern NSString * const MMEEventTypeMapDragEnd;
 extern NSString * const MMEEventTypeLocation;
+extern NSString * const MMEEventTypeVisit;
 extern NSString * const MMEEventTypeLocalDebug;
 
 // Gestures
@@ -39,6 +40,8 @@ extern NSString * const MMEEventGestureRotateStart;
 extern NSString * const MMEEventGesturePitchStart;
 
 // Event keys
+extern NSString * const MMEEventKeyArrivalDate;
+extern NSString * const MMEEventKeyDepartureDate;
 extern NSString * const MMEEventKeyLatitude;
 extern NSString * const MMEEventKeyLongitude;
 extern NSString * const MMEEventKeyZoomLevel;

--- a/MapboxMobileEvents/MMEConstants.m
+++ b/MapboxMobileEvents/MMEConstants.m
@@ -37,7 +37,7 @@ NSString * const MMEEventGestureRotateStart = @"Rotation";
 NSString * const MMEEventGesturePitchStart = @"Pitch";
 
 NSString * const MMEEventKeyArrivalDate = @"arrivalDate";
-NSString * const MMEEventKeyDepartureDate = @"arrivalDate";
+NSString * const MMEEventKeyDepartureDate = @"departureDate";
 NSString * const MMEEventKeyLatitude = @"lat";
 NSString * const MMEEventKeyLongitude = @"lng";
 NSString * const MMEEventKeyZoomLevel = @"zoom";

--- a/MapboxMobileEvents/MMEConstants.m
+++ b/MapboxMobileEvents/MMEConstants.m
@@ -24,6 +24,7 @@ NSString * const MMEEventTypeMapLoad = @"map.load";
 NSString * const MMEEventTypeMapTap = @"map.click";
 NSString * const MMEEventTypeMapDragEnd = @"map.dragend";
 NSString * const MMEEventTypeLocation = @"location";
+NSString * const MMEEventTypeVisit = @"visit";
 NSString * const MMEEventTypeLocalDebug = @"debug";
 
 NSString * const MMEEventGestureSingleTap = @"SingleTap";
@@ -35,6 +36,8 @@ NSString * const MMEEventGesturePinchStart = @"Pinch";
 NSString * const MMEEventGestureRotateStart = @"Rotation";
 NSString * const MMEEventGesturePitchStart = @"Pitch";
 
+NSString * const MMEEventKeyArrivalDate = @"arrivalDate";
+NSString * const MMEEventKeyDepartureDate = @"arrivalDate";
 NSString * const MMEEventKeyLatitude = @"lat";
 NSString * const MMEEventKeyLongitude = @"lng";
 NSString * const MMEEventKeyZoomLevel = @"zoom";

--- a/MapboxMobileEvents/MMEEvent.h
+++ b/MapboxMobileEvents/MMEEvent.h
@@ -9,6 +9,7 @@
 
 + (instancetype)turnstileEventWithAttributes:(NSDictionary *)attributes;
 + (instancetype)locationEventWithAttributes:(NSDictionary *)attributes instanceIdentifer:(NSString *)instanceIdentifer commonEventData:(MMECommonEventData *)commonEventData;
++ (instancetype)visitEventWithAttributes:(NSDictionary *)attributes;
 + (instancetype)mapLoadEventWithDateString:(NSString *)dateString commonEventData:(MMECommonEventData *)commonEventData;
 + (instancetype)mapTapEventWithDateString:(NSString *)dateString attributes:(NSDictionary *)attributes;
 + (instancetype)mapDragEndEventWithDateString:(NSString *)dateString attributes:(NSDictionary *)attributes;

--- a/MapboxMobileEvents/MMEEvent.m
+++ b/MapboxMobileEvents/MMEEvent.m
@@ -30,6 +30,16 @@
     return locationEvent;
 }
 
++ (instancetype)visitEventWithAttributes:(NSDictionary *)attributes {
+    MMEEvent *visitEvent = [[MMEEvent alloc] init];
+    visitEvent.name = MMEEventTypeVisit;
+    NSMutableDictionary *commonAttributes = [NSMutableDictionary dictionary];
+    commonAttributes[MMEEventKeyEvent] = visitEvent.name;
+    [commonAttributes addEntriesFromDictionary:attributes];
+    visitEvent.attributes = commonAttributes;
+    return visitEvent;
+}
+
 + (instancetype)mapLoadEventWithDateString:(NSString *)dateString commonEventData:(MMECommonEventData *)commonEventData; {
     MMEEvent *mapLoadEvent = [[MMEEvent alloc] init];
     mapLoadEvent.name = MMEEventTypeMapLoad;

--- a/MapboxMobileEvents/MMEEventsManager.h
+++ b/MapboxMobileEvents/MMEEventsManager.h
@@ -3,18 +3,9 @@
 #import "MMETypes.h"
 #import <CoreLocation/CoreLocation.h>
 
-
-@class MMELocationManager;
-
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol MMEEventsManagerDelegate;
-
-@protocol MMEEventsManagerDelegate <NSObject>
-
-- (void)locationManager:(MMELocationManager *)locationManager didUpdateLocations:(NSArray<CLLocation *> *)locations;
-
-@end
 
 @interface MMEEventsManager : NSObject
 
@@ -44,5 +35,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@protocol MMEEventsManagerDelegate <NSObject>
+
+@optional
+
+- (void)eventsManager:(MMEEventsManager *)eventsManager didUpdateLocations:(NSArray<CLLocation *> *)locations;
+- (void)eventsManager:(MMEEventsManager *)eventsManager didVisit:(CLVisit *)visit;
+
+@end
 
 NS_ASSUME_NONNULL_END

--- a/MapboxMobileEvents/MMEEventsManager.m
+++ b/MapboxMobileEvents/MMEEventsManager.m
@@ -440,8 +440,8 @@
                                             instanceIdentifer:self.uniqueIdentifer.rollingInstanceIdentifer
                                               commonEventData:self.commonEventData]];
     }
-    if ([self.delegate respondsToSelector:@selector(locationManager:didUpdateLocations:)]) {
-        [self.delegate locationManager:self.locationManager didUpdateLocations:locations];
+    if ([self.delegate respondsToSelector:@selector(eventsManager:didUpdateLocations:)]) {
+        [self.delegate eventsManager:self didUpdateLocations:locations];
     }
 }
 
@@ -463,6 +463,23 @@
 - (void)locationManagerDidStopLocationUpdates:(MMELocationManager *)locationManager {
     [self pushDebugEventWithAttributes:@{MMEDebugEventType: MMEDebugEventTypeLocationManager,
                                          MMEEventKeyLocalDebugDescription: @"Location manager stopped location updates"}];
+}
+
+- (void)locationManager:(MMELocationManager *)locationManager didVisit:(CLVisit *)visit {
+    [self pushDebugEventWithAttributes:@{MMEDebugEventType: MMEDebugEventTypeLocationManager,
+                                         MMEEventKeyLocalDebugDescription: [NSString stringWithFormat:@"Location manager visit %@", visit]}];
+    
+    CLLocation *location = [[CLLocation alloc] initWithLatitude:visit.coordinate.latitude longitude:visit.coordinate.longitude];
+    MMEMapboxEventAttributes *eventAttributes = @{MMEEventKeyLatitude: @([location mme_latitudeRoundedWithPrecision:7]),
+                                                  MMEEventKeyLongitude: @([location mme_longitudeRoundedWithPrecision:7]),
+                                                  MMEEventHorizontalAccuracy: @(visit.horizontalAccuracy),
+                                                  MMEEventKeyArrivalDate: [self.dateWrapper formattedDateStringForDate:visit.arrivalDate],
+                                                  MMEEventKeyDepartureDate: [self.dateWrapper formattedDateStringForDate:visit.departureDate]};
+    [self pushEvent:[MMEEvent visitEventWithAttributes:eventAttributes]];
+
+    if ([self.delegate respondsToSelector:@selector(eventsManager:didVisit:)]) {
+        [self.delegate eventsManager:self didVisit:visit];
+    }
 }
 
 @end

--- a/MapboxMobileEvents/MMEEventsManager.m
+++ b/MapboxMobileEvents/MMEEventsManager.m
@@ -80,7 +80,6 @@
     }
 #pragma clang diagnostic pop
     
-    
     self.paused = YES;
     
     self.locationManager = [[MMELocationManager alloc] init];
@@ -245,7 +244,6 @@
                                              MMEEventKeyLocalDebugDescription: @"No iOS version available, can not send turntile event"}];
         return;
     }
-    
     
     NSDictionary *turnstileEventAttributes = @{MMEEventKeyEvent: MMEEventTypeAppUserTurnstile,
                                                MMEEventKeyCreated: [self.dateWrapper formattedDateStringForDate:[self.dateWrapper date]],
@@ -470,7 +468,8 @@
                                          MMEEventKeyLocalDebugDescription: [NSString stringWithFormat:@"Location manager visit %@", visit]}];
     
     CLLocation *location = [[CLLocation alloc] initWithLatitude:visit.coordinate.latitude longitude:visit.coordinate.longitude];
-    MMEMapboxEventAttributes *eventAttributes = @{MMEEventKeyLatitude: @([location mme_latitudeRoundedWithPrecision:7]),
+    MMEMapboxEventAttributes *eventAttributes = @{MMEEventKeyCreated: [self.dateWrapper formattedDateStringForDate:[location timestamp]],
+                                                  MMEEventKeyLatitude: @([location mme_latitudeRoundedWithPrecision:7]),
                                                   MMEEventKeyLongitude: @([location mme_longitudeRoundedWithPrecision:7]),
                                                   MMEEventHorizontalAccuracy: @(visit.horizontalAccuracy),
                                                   MMEEventKeyArrivalDate: [self.dateWrapper formattedDateStringForDate:visit.arrivalDate],

--- a/MapboxMobileEvents/MMELocationManager.h
+++ b/MapboxMobileEvents/MMELocationManager.h
@@ -39,5 +39,6 @@ extern NSString * const MMELocationManagerRegionIdentifier;
 - (void)locationManagerBackgroundLocationUpdatesDidTimeout:(MMELocationManager *)locationManager;
 - (void)locationManagerBackgroundLocationUpdatesDidAutomaticallyPause:(MMELocationManager *)locationManager;
 - (void)locationManagerDidStopLocationUpdates:(MMELocationManager *)locationManager;
+- (void)locationManager:(MMELocationManager *)locationManager didVisit:(CLVisit *)visit;
 
 @end

--- a/MapboxMobileEvents/MMELocationManager.m
+++ b/MapboxMobileEvents/MMELocationManager.m
@@ -35,6 +35,9 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
 }
 
 - (void)startUpdatingLocation {
+    if (![CLLocationManager locationServicesEnabled]) {
+        return;
+    }
     if ([self isUpdatingLocation]) {
         return;
     }
@@ -47,6 +50,7 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
     if ([self isUpdatingLocation]) {
         [self.locationManager stopUpdatingLocation];
         [self.locationManager stopMonitoringSignificantLocationChanges];
+        [self.locationManager stopMonitoringVisits];
         self.updatingLocation = NO;
         if ([self.delegate respondsToSelector:@selector(locationManagerDidStopLocationUpdates:)]) {
             [self.delegate locationManagerDidStopLocationUpdates:self];
@@ -120,6 +124,10 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
                 #pragma clang diagnostic pop
             }
         }
+        
+        if (authorizedAlways) {
+            [self.locationManager startMonitoringVisits];
+        }
 
         [self.locationManager startUpdatingLocation];
         self.updatingLocation = YES;
@@ -191,6 +199,12 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
 - (void)locationManager:(CLLocationManager *)locationManager didExitRegion:(CLRegion *)region {
     [self startBackgroundTimeoutTimer];
     [self.locationManager startUpdatingLocation];
+}
+
+- (void)locationManager:(CLLocationManager *)manager didVisit:(CLVisit *)visit {
+    if ([self.delegate respondsToSelector:@selector(locationManager:didVisit:)]) {
+        [self.delegate locationManager:self didVisit:visit];
+    }
 }
 
 - (void)locationManagerDidPauseLocationUpdates:(CLLocationManager *)locationManager {

--- a/MapboxMobileEventsTests/MMELocationManagerTests.mm
+++ b/MapboxMobileEventsTests/MMELocationManagerTests.mm
@@ -399,6 +399,19 @@ describe(@"MMELocationManager", ^{
                 locationManager.backgroundLocationServiceTimeoutTimer should be_nil;
             });
             
+            context(@"when a visit is received", ^{
+                __block CLVisit *visit;
+                
+                beforeEach(^{
+                    visit = [[CLVisit alloc] init];
+                    [locationManager locationManager:locationManagerInstance didVisit:visit];
+                });
+                
+                it(@"tells its delegate", ^{
+                    locationManager.delegate should have_received(@selector(locationManager:didVisit:)).with(locationManager, visit);
+                });
+            });
+            
             context(@"when location data are received", ^{
                 beforeEach(^{
                     [locationManager startUpdatingLocation];


### PR DESCRIPTION
This also refactors the MMEEventsManagerDelegate to reflect that it (the eventsManager) is the source of the delegate callbacks and not its location manager.