### PR TITLE
Port Radius Profile Configuration

### DIFF
--- a/MapboxMobileEvents.podspec
+++ b/MapboxMobileEvents.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.name = 'MapboxMobileEvents'
-  s.version = "0.3.1"
+  s.version = "0.4.0"
   s.summary = "Mapbox Mobile Events"
 
   s.description  = "Collects usage information to help Mapbox improve its products."

--- a/MapboxMobileEvents.xcodeproj/project.pbxproj
+++ b/MapboxMobileEvents.xcodeproj/project.pbxproj
@@ -134,6 +134,9 @@
 		40FB437D1EFAFAE900EC5BC0 /* MMETimerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 40FB437B1EFAFAE900EC5BC0 /* MMETimerManager.m */; };
 		40FB437E1EFAFAE900EC5BC0 /* MMETimerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 40FB437B1EFAFAE900EC5BC0 /* MMETimerManager.m */; };
 		40FB43801EFAFDCF00EC5BC0 /* MMETimerManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 40FB437F1EFAFDCF00EC5BC0 /* MMETimerManagerTests.m */; };
+		AC518E072034C0B500EBC820 /* MMEEventsService.h in Headers */ = {isa = PBXBuildFile; fileRef = AC518E052034C0B500EBC820 /* MMEEventsService.h */; };
+		AC518E082034C0B500EBC820 /* MMEEventsService.m in Sources */ = {isa = PBXBuildFile; fileRef = AC518E062034C0B500EBC820 /* MMEEventsService.m */; };
+		AC518E092034C3E700EBC820 /* MMEEventsService.m in Sources */ = {isa = PBXBuildFile; fileRef = AC518E062034C0B500EBC820 /* MMEEventsService.m */; };
 		AC611F271FCDED2F00ABBF6D /* MMEEventLogReportViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = AC611F251FCDED2F00ABBF6D /* MMEEventLogReportViewController.h */; };
 		AC611F281FCDED2F00ABBF6D /* MMEEventLogReportViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = AC611F261FCDED2F00ABBF6D /* MMEEventLogReportViewController.m */; };
 		ACB6F21E1F7BF71B0032A916 /* MMELocationManagerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACB6F21D1F7BF71B0032A916 /* MMELocationManagerTests.mm */; };
@@ -283,6 +286,8 @@
 		40FB437A1EFAFAE900EC5BC0 /* MMETimerManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MMETimerManager.h; sourceTree = "<group>"; };
 		40FB437B1EFAFAE900EC5BC0 /* MMETimerManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MMETimerManager.m; sourceTree = "<group>"; };
 		40FB437F1EFAFDCF00EC5BC0 /* MMETimerManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MMETimerManagerTests.m; sourceTree = "<group>"; };
+		AC518E052034C0B500EBC820 /* MMEEventsService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MMEEventsService.h; sourceTree = "<group>"; };
+		AC518E062034C0B500EBC820 /* MMEEventsService.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MMEEventsService.m; sourceTree = "<group>"; };
 		AC611F251FCDED2F00ABBF6D /* MMEEventLogReportViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MMEEventLogReportViewController.h; sourceTree = "<group>"; };
 		AC611F261FCDED2F00ABBF6D /* MMEEventLogReportViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MMEEventLogReportViewController.m; sourceTree = "<group>"; };
 		ACB6F21D1F7BF71B0032A916 /* MMELocationManagerTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MMELocationManagerTests.mm; sourceTree = "<group>"; };
@@ -384,6 +389,8 @@
 				4036EFBD1ED37D56009C40BA /* MMEEventLogger.m */,
 				AC611F251FCDED2F00ABBF6D /* MMEEventLogReportViewController.h */,
 				AC611F261FCDED2F00ABBF6D /* MMEEventLogReportViewController.m */,
+				AC518E052034C0B500EBC820 /* MMEEventsService.h */,
+				AC518E062034C0B500EBC820 /* MMEEventsService.m */,
 				40FB43751EF9EA7800EC5BC0 /* MMEEventsConfiguration.h */,
 				40FB43761EF9EA7800EC5BC0 /* MMEEventsConfiguration.m */,
 				40C9E2791EA542BC00744FE7 /* MMEEventsManager.h */,
@@ -600,6 +607,7 @@
 				40834B9F1FDF62C900C1BD0D /* MMENamespacedDependencies.h in Headers */,
 				409115301F16AE6100F4250B /* MMETrustKitWrapper.h in Headers */,
 				40C611861F18319000E30A6C /* TSKPinningValidator_Private.h in Headers */,
+				AC518E072034C0B500EBC820 /* MMEEventsService.h in Headers */,
 				40C611831F18319000E30A6C /* TSKPinningValidator.h in Headers */,
 				40C9E27B1EA542BC00744FE7 /* MMEEventsManager.h in Headers */,
 				40C611731F18319000E30A6C /* TSKReportsRateLimiter.h in Headers */,
@@ -804,6 +812,7 @@
 				40C611681F18319000E30A6C /* TSKSPKIHashCache.m in Sources */,
 				40F16C971F04514100DF338D /* MMEReachability.m in Sources */,
 				40C9E2801EA5473F00744FE7 /* MMELocationManager.m in Sources */,
+				AC518E082034C0B500EBC820 /* MMEEventsService.m in Sources */,
 				40C611841F18319000E30A6C /* TSKPinningValidator.m in Sources */,
 				AC611F281FCDED2F00ABBF6D /* MMEEventLogReportViewController.m in Sources */,
 				40C611641F18319000E30A6C /* ssl_pin_verifier.m in Sources */,
@@ -874,6 +883,7 @@
 				408596671ED086F4003BD29D /* MMECommonEventData.m in Sources */,
 				408596631ED086E8003BD29D /* CLLocation+MMEMobileEvents.m in Sources */,
 				40C611781F18319000E30A6C /* vendor_identifier.m in Sources */,
+				AC518E092034C3E700EBC820 /* MMEEventsService.m in Sources */,
 				408596611ED086E2003BD29D /* MMEAPIClient.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MapboxMobileEvents.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/MapboxMobileEvents.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/MapboxMobileEvents/Info.plist
+++ b/MapboxMobileEvents/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.1</string>
+	<string>0.4.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/MapboxMobileEvents/MMEEventsConfiguration.h
+++ b/MapboxMobileEvents/MMEEventsConfiguration.h
@@ -1,11 +1,14 @@
 #import <Foundation/Foundation.h>
+#import <CoreLocation/CoreLocation.h>
 
 @interface MMEEventsConfiguration : NSObject
 
 @property (nonatomic) NSUInteger eventFlushCountThreshold;
 @property (nonatomic) NSUInteger eventFlushSecondsThreshold;
 @property (nonatomic) NSTimeInterval instanceIdentifierRotationTimeInterval;
+@property (nonatomic) CLLocationDistance locationManagerHibernationRadius;
 
 + (instancetype)defaultEventsConfiguration;
++ (instancetype)eventsConfigurationWithVariableRadius:(CLLocationDistance)radius;
 
 @end

--- a/MapboxMobileEvents/MMEEventsConfiguration.m
+++ b/MapboxMobileEvents/MMEEventsConfiguration.m
@@ -1,12 +1,33 @@
 #import "MMEEventsConfiguration.h"
 
+static const CLLocationDistance kHibernationRadiusDefault = 300.0;
+static const CLLocationDistance kHibernationRadiusWide = 1200.0;
+static const NSUInteger kEventFlushCountThresholdDefault = 180;
+static const NSUInteger kEventFlushSecondsThresholdDefault = 180;
+static const NSTimeInterval kInstanceIdentifierRotationTimeIntervalDefault = 24 * 3600; // 24 hours
+
 @implementation MMEEventsConfiguration
 
 + (instancetype)defaultEventsConfiguration {
     MMEEventsConfiguration *configuration = [[MMEEventsConfiguration alloc] init];
-    configuration.eventFlushCountThreshold = 180;
-    configuration.eventFlushSecondsThreshold = 180;
-    configuration.instanceIdentifierRotationTimeInterval = 24 * 3600; // 24 hours
+    configuration.eventFlushCountThreshold = kEventFlushCountThresholdDefault;
+    configuration.eventFlushSecondsThreshold = kEventFlushSecondsThresholdDefault;
+    configuration.instanceIdentifierRotationTimeInterval = kInstanceIdentifierRotationTimeIntervalDefault;
+    configuration.locationManagerHibernationRadius = kHibernationRadiusDefault;
+    return configuration;
+}
+
++ (instancetype)eventsConfigurationWithVariableRadius:(CLLocationDistance)radius {
+    MMEEventsConfiguration *configuration = [[MMEEventsConfiguration alloc] init];
+    configuration.eventFlushCountThreshold = kEventFlushCountThresholdDefault;
+    configuration.eventFlushSecondsThreshold = kEventFlushSecondsThresholdDefault;
+    configuration.instanceIdentifierRotationTimeInterval = kInstanceIdentifierRotationTimeIntervalDefault;
+    
+    if (radius == 0) radius = kHibernationRadiusWide / 2; //return a median radius if no variable radius is set
+    else if (radius < kHibernationRadiusDefault) radius = kHibernationRadiusDefault;
+    else if (radius > kHibernationRadiusWide) radius = kHibernationRadiusWide;
+    
+    configuration.locationManagerHibernationRadius = radius;
     return configuration;
 }
 

--- a/MapboxMobileEvents/MMEEventsManager.m
+++ b/MapboxMobileEvents/MMEEventsManager.m
@@ -73,12 +73,9 @@
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(pauseOrResumeMetricsCollectionIfRequired) name:UIApplicationDidEnterBackgroundNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(pauseOrResumeMetricsCollectionIfRequired) name:UIApplicationDidBecomeActiveNotification object:nil];
     
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunguarded-availability"
-    if (&NSProcessInfoPowerStateDidChangeNotification != NULL) {
+    if (@available(iOS 9.0, *)) {
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(pauseOrResumeMetricsCollectionIfRequired) name:NSProcessInfoPowerStateDidChangeNotification object:nil];
     }
-#pragma clang diagnostic pop
     
     self.paused = YES;
     

--- a/MapboxMobileEvents/MMEEventsManager.m
+++ b/MapboxMobileEvents/MMEEventsManager.m
@@ -12,6 +12,7 @@
 #import "MMENSDateWrapper.h"
 #import "MMECategoryLoader.h"
 #import "CLLocation+MMEMobileEvents.h"
+#import "MMEEventsService.h"
 #import <CoreLocation/CoreLocation.h>
 
 @interface MMEEventsManager () <MMELocationManagerDelegate>
@@ -37,12 +38,12 @@
 + (instancetype)sharedManager {
     static MMEEventsManager *_sharedManager;
     static dispatch_once_t onceToken;
-
+    
     dispatch_once(&onceToken, ^{
         [MMECategoryLoader loadCategories];
         _sharedManager = [[MMEEventsManager alloc] init];
     });
-
+    
     return _sharedManager;
 }
 
@@ -54,7 +55,7 @@
         _accountType = 0;
         _eventQueue = [NSMutableArray array];
         _commonEventData = [[MMECommonEventData alloc] init];
-        _configuration = [MMEEventsConfiguration defaultEventsConfiguration];
+        _configuration = [MMEEventsService.sharedService configuration];
         _uniqueIdentifer = [[MMEUniqueIdentifier alloc] initWithTimeInterval:_configuration.instanceIdentifierRotationTimeInterval];
         _application = [[MMEUIApplicationWrapper alloc] init];
         _dateWrapper = [[MMENSDateWrapper alloc] init];

--- a/MapboxMobileEvents/MMEEventsService.h
+++ b/MapboxMobileEvents/MMEEventsService.h
@@ -1,0 +1,15 @@
+#import <Foundation/Foundation.h>
+#import <CoreLocation/CoreLocation.h>
+#import "MMEEventsConfiguration.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MMEEventsService : NSObject
+
+@property (nonatomic) MMEEventsConfiguration *configuration;
+
++ (nullable instancetype)sharedService;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MapboxMobileEvents/MMEEventsService.m
+++ b/MapboxMobileEvents/MMEEventsService.m
@@ -1,0 +1,36 @@
+#import "MMEEventsService.h"
+
+NSString *const kMMEEventsProfile = @"MMEEventsProfile";
+NSString *const kMMERadiusSize = @"MMEGeofenceRadius";
+
+static NSString *const kConfigHibernationRadiusVariableKey = @"VariableGeofence";
+
+@implementation MMEEventsService
+
+- (instancetype) init {
+    self = [super init];
+    if (self) {
+        self.configuration = [self configurationFromKey:[[NSBundle mainBundle] objectForInfoDictionaryKey:kMMEEventsProfile]];
+    }
+    return self;
+}
+
++ (nullable instancetype)sharedService {
+    static dispatch_once_t onceToken;
+    static MMEEventsService *_sharedService;
+    dispatch_once(&onceToken, ^{
+        _sharedService = [[self alloc] init];
+    });
+    return _sharedService;
+}
+
+- (MMEEventsConfiguration *)configurationFromKey:(NSString *)key {
+    if ([key isEqualToString:kConfigHibernationRadiusVariableKey]) {
+        return [MMEEventsConfiguration eventsConfigurationWithVariableRadius:[[[NSBundle mainBundle] objectForInfoDictionaryKey:kMMERadiusSize] doubleValue]];
+    } else {
+        return [MMEEventsConfiguration defaultEventsConfiguration];
+    }
+    return nil;
+}
+
+@end

--- a/MapboxMobileEvents/MMELocationManager.m
+++ b/MapboxMobileEvents/MMELocationManager.m
@@ -73,12 +73,8 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
     
     CLAuthorizationStatus authorizationStatus = [CLLocationManager authorizationStatus];
     if (authorizationStatus == kCLAuthorizationStatusAuthorizedWhenInUse && self.hostAppHasBackgroundCapability) {
-        // On iOS 9 and above also allow background location updates
-        if ([self.locationManager respondsToSelector:@selector(allowsBackgroundLocationUpdates)]) {
-            #pragma clang diagnostic push
-            #pragma clang diagnostic ignored "-Wunguarded-availability"
-                self.locationManager.allowsBackgroundLocationUpdates = self.isMetricsEnabledForInUsePermissions;
-            #pragma clang diagnostic pop
+        if (@available(iOS 9.0, *)) {
+            self.locationManager.allowsBackgroundLocationUpdates = self.isMetricsEnabledForInUsePermissions;
         }
     }
 }
@@ -103,11 +99,8 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
         if (authorizedAlways && self.hostAppHasBackgroundCapability) {
             [self.locationManager startMonitoringSignificantLocationChanges];
             [self startBackgroundTimeoutTimer];
-            if ([self.locationManager respondsToSelector:@selector(allowsBackgroundLocationUpdates)]) {
-                #pragma clang diagnostic push
-                #pragma clang diagnostic ignored "-Wunguarded-availability"
-                    self.locationManager.allowsBackgroundLocationUpdates = YES;
-                #pragma clang diagnostic pop
+            if (@available(iOS 9.0, *)) {
+                self.locationManager.allowsBackgroundLocationUpdates = YES;
             }
         }
           
@@ -117,11 +110,8 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
         // permissions involve navigation where a user would want and expect the app to be running / navigating
         // even if it is not in the foreground
         if (authorizationStatus == kCLAuthorizationStatusAuthorizedWhenInUse && self.hostAppHasBackgroundCapability) {
-            if ([self.locationManager respondsToSelector:@selector(allowsBackgroundLocationUpdates)]) {
-                #pragma clang diagnostic push
-                #pragma clang diagnostic ignored "-Wunguarded-availability"
-                    self.locationManager.allowsBackgroundLocationUpdates = self.isMetricsEnabledForInUsePermissions;
-                #pragma clang diagnostic pop
+            if (@available(iOS 9.0, *)) {
+                self.locationManager.allowsBackgroundLocationUpdates = self.isMetricsEnabledForInUsePermissions;
             }
         }
         

--- a/MapboxMobileEvents/MMELocationManager.m
+++ b/MapboxMobileEvents/MMELocationManager.m
@@ -1,12 +1,13 @@
 #import "MMELocationManager.h"
 #import "MMEUIApplicationWrapper.h"
 #import "MMEDependencyManager.h"
+#import "MMEEventsService.h"
+#import "MMEEventsConfiguration.h"
 #import <CoreLocation/CoreLocation.h>
 
 static const NSTimeInterval MMELocationManagerHibernationTimeout = 300.0;
 static const NSTimeInterval MMELocationManagerHibernationPollInterval = 5.0;
 
-const CLLocationDistance MMELocationManagerHibernationRadius = 300.0;
 const CLLocationDistance MMELocationManagerDistanceFilter = 5.0;
 
 NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegionIdentifier.fence.center";
@@ -19,6 +20,7 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
 @property (nonatomic) NSDate *backgroundLocationServiceTimeoutAllowedDate;
 @property (nonatomic) NSTimer *backgroundLocationServiceTimeoutTimer;
 @property (nonatomic) BOOL hostAppHasBackgroundCapability;
+@property (nonatomic) MMEEventsConfiguration *configuration;
 
 @end
 
@@ -30,6 +32,7 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
         _application = [[MMEUIApplicationWrapper alloc] init];
         NSArray *backgroundModes = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIBackgroundModes"];
         _hostAppHasBackgroundCapability = [backgroundModes containsObject:@"location"];
+        _configuration = [MMEEventsService.sharedService configuration];
     }
     return self;
 }
@@ -71,10 +74,10 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
     if (authorizationStatus == kCLAuthorizationStatusAuthorizedWhenInUse && self.hostAppHasBackgroundCapability) {
         // On iOS 9 and above also allow background location updates
         if ([self.locationManager respondsToSelector:@selector(allowsBackgroundLocationUpdates)]) {
-            #pragma clang diagnostic push
-            #pragma clang diagnostic ignored "-Wunguarded-availability"
-                self.locationManager.allowsBackgroundLocationUpdates = self.isMetricsEnabledForInUsePermissions;
-            #pragma clang diagnostic pop
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability"
+            self.locationManager.allowsBackgroundLocationUpdates = self.isMetricsEnabledForInUsePermissions;
+#pragma clang diagnostic pop
         }
     }
 }
@@ -89,24 +92,24 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
 
 - (void)startLocationServices {
     CLAuthorizationStatus authorizationStatus = [CLLocationManager authorizationStatus];
-
+    
     BOOL authorizedAlways = authorizationStatus == kCLAuthorizationStatusAuthorizedAlways;
-
+    
     if (authorizedAlways || authorizationStatus == kCLAuthorizationStatusAuthorizedWhenInUse) {
-
+        
         // If the host app can run in the background with `always` location permissions then allow background
         // updates and start the significant location change service and background timeout timer
         if (authorizedAlways && self.hostAppHasBackgroundCapability) {
             [self.locationManager startMonitoringSignificantLocationChanges];
             [self startBackgroundTimeoutTimer];
             if ([self.locationManager respondsToSelector:@selector(allowsBackgroundLocationUpdates)]) {
-                #pragma clang diagnostic push
-                #pragma clang diagnostic ignored "-Wunguarded-availability"
-                    self.locationManager.allowsBackgroundLocationUpdates = YES;
-                #pragma clang diagnostic pop
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability"
+                self.locationManager.allowsBackgroundLocationUpdates = YES;
+#pragma clang diagnostic pop
             }
         }
-          
+        
         // If authorization status is when in use specifically, allow background location updates based on
         // if the library is configured to do so. Don't worry about significant location change and the
         // background timer (just above) since all use cases for background collection with in use only
@@ -114,16 +117,16 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
         // even if it is not in the foreground
         if (authorizationStatus == kCLAuthorizationStatusAuthorizedWhenInUse && self.hostAppHasBackgroundCapability) {
             if ([self.locationManager respondsToSelector:@selector(allowsBackgroundLocationUpdates)]) {
-                #pragma clang diagnostic push
-                #pragma clang diagnostic ignored "-Wunguarded-availability"
-                    self.locationManager.allowsBackgroundLocationUpdates = self.isMetricsEnabledForInUsePermissions;
-                #pragma clang diagnostic pop
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability"
+                self.locationManager.allowsBackgroundLocationUpdates = self.isMetricsEnabledForInUsePermissions;
+#pragma clang diagnostic pop
             }
         }
-
+        
         [self.locationManager startUpdatingLocation];
         self.updatingLocation = YES;
-
+        
         if ([self.delegate respondsToSelector:@selector(locationManagerDidStartLocationUpdates:)]) {
             [self.delegate locationManagerDidStartLocationUpdates:self];
         }
@@ -134,13 +137,13 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
     if (!self.isUpdatingLocation) {
         return;
     }
-
+    
     if (self.application.applicationState == UIApplicationStateActive ||
         self.application.applicationState == UIApplicationStateInactive ) {
         [self startBackgroundTimeoutTimer];
         return;
     }
-
+    
     NSTimeInterval timeIntervalSinceTimeoutAllowed = [[NSDate date] timeIntervalSinceDate:self.backgroundLocationServiceTimeoutAllowedDate];
     if (timeIntervalSinceTimeoutAllowed > 0) {
         [self.locationManager stopUpdatingLocation];
@@ -158,7 +161,7 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
 }
 
 - (void)establishRegionMonitoringForLocation:(CLLocation *)location {
-    CLCircularRegion *region = [[CLCircularRegion alloc] initWithCenter:location.coordinate radius:MMELocationManagerHibernationRadius identifier:MMELocationManagerRegionIdentifier];
+    CLCircularRegion *region = [[CLCircularRegion alloc] initWithCenter:location.coordinate radius:self.configuration.locationManagerHibernationRadius identifier:MMELocationManagerRegionIdentifier];
     region.notifyOnEntry = NO;
     region.notifyOnExit = YES;
     [self.locationManager startMonitoringForRegion:region];
@@ -180,7 +183,7 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
     if (location.speed > 0.0) {
         [self startBackgroundTimeoutTimer];
     }
-    if ([self.locationManager.monitoredRegions anyObject] == nil || location.horizontalAccuracy < MMELocationManagerHibernationRadius) {
+    if ([self.locationManager.monitoredRegions anyObject] == nil || location.horizontalAccuracy < self.configuration.locationManagerHibernationRadius) {
         [self establishRegionMonitoringForLocation:location];
     }
     if ([self.delegate respondsToSelector:@selector(locationManager:didUpdateLocations:)]) {
@@ -200,3 +203,4 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
 }
 
 @end
+

--- a/MapboxMobileEvents/MMELocationManager.m
+++ b/MapboxMobileEvents/MMELocationManager.m
@@ -1,12 +1,13 @@
 #import "MMELocationManager.h"
 #import "MMEUIApplicationWrapper.h"
 #import "MMEDependencyManager.h"
+#import "MMEEventsService.h"
+#import "MMEEventsConfiguration.h"
 #import <CoreLocation/CoreLocation.h>
 
 static const NSTimeInterval MMELocationManagerHibernationTimeout = 300.0;
 static const NSTimeInterval MMELocationManagerHibernationPollInterval = 5.0;
 
-const CLLocationDistance MMELocationManagerHibernationRadius = 300.0;
 const CLLocationDistance MMELocationManagerDistanceFilter = 5.0;
 
 NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegionIdentifier.fence.center";
@@ -19,6 +20,7 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
 @property (nonatomic) NSDate *backgroundLocationServiceTimeoutAllowedDate;
 @property (nonatomic) NSTimer *backgroundLocationServiceTimeoutTimer;
 @property (nonatomic) BOOL hostAppHasBackgroundCapability;
+@property (nonatomic) MMEEventsConfiguration *configuration;
 
 @end
 
@@ -30,6 +32,7 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
         _application = [[MMEUIApplicationWrapper alloc] init];
         NSArray *backgroundModes = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIBackgroundModes"];
         _hostAppHasBackgroundCapability = [backgroundModes containsObject:@"location"];
+        _configuration = [MMEEventsService.sharedService configuration];
     }
     return self;
 }
@@ -89,11 +92,11 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
 
 - (void)startLocationServices {
     CLAuthorizationStatus authorizationStatus = [CLLocationManager authorizationStatus];
-
+    
     BOOL authorizedAlways = authorizationStatus == kCLAuthorizationStatusAuthorizedAlways;
-
+    
     if (authorizedAlways || authorizationStatus == kCLAuthorizationStatusAuthorizedWhenInUse) {
-
+        
         // If the host app can run in the background with `always` location permissions then allow background
         // updates and start the significant location change service and background timeout timer
         if (authorizedAlways && self.hostAppHasBackgroundCapability) {
@@ -103,7 +106,7 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
                 self.locationManager.allowsBackgroundLocationUpdates = YES;
             }
         }
-          
+        
         // If authorization status is when in use specifically, allow background location updates based on
         // if the library is configured to do so. Don't worry about significant location change and the
         // background timer (just above) since all use cases for background collection with in use only
@@ -121,7 +124,7 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
 
         [self.locationManager startUpdatingLocation];
         self.updatingLocation = YES;
-
+        
         if ([self.delegate respondsToSelector:@selector(locationManagerDidStartLocationUpdates:)]) {
             [self.delegate locationManagerDidStartLocationUpdates:self];
         }
@@ -132,13 +135,13 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
     if (!self.isUpdatingLocation) {
         return;
     }
-
+    
     if (self.application.applicationState == UIApplicationStateActive ||
         self.application.applicationState == UIApplicationStateInactive ) {
         [self startBackgroundTimeoutTimer];
         return;
     }
-
+    
     NSTimeInterval timeIntervalSinceTimeoutAllowed = [[NSDate date] timeIntervalSinceDate:self.backgroundLocationServiceTimeoutAllowedDate];
     if (timeIntervalSinceTimeoutAllowed > 0) {
         [self.locationManager stopUpdatingLocation];
@@ -156,7 +159,7 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
 }
 
 - (void)establishRegionMonitoringForLocation:(CLLocation *)location {
-    CLCircularRegion *region = [[CLCircularRegion alloc] initWithCenter:location.coordinate radius:MMELocationManagerHibernationRadius identifier:MMELocationManagerRegionIdentifier];
+    CLCircularRegion *region = [[CLCircularRegion alloc] initWithCenter:location.coordinate radius:self.configuration.locationManagerHibernationRadius identifier:MMELocationManagerRegionIdentifier];
     region.notifyOnEntry = NO;
     region.notifyOnExit = YES;
     [self.locationManager startMonitoringForRegion:region];
@@ -178,7 +181,7 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
     if (location.speed > 0.0) {
         [self startBackgroundTimeoutTimer];
     }
-    if ([self.locationManager.monitoredRegions anyObject] == nil || location.horizontalAccuracy < MMELocationManagerHibernationRadius) {
+    if ([self.locationManager.monitoredRegions anyObject] == nil || location.horizontalAccuracy < self.configuration.locationManagerHibernationRadius) {
         [self establishRegionMonitoringForLocation:location];
     }
     if ([self.delegate respondsToSelector:@selector(locationManager:didUpdateLocations:)]) {
@@ -204,3 +207,4 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
 }
 
 @end
+

--- a/MapboxMobileEvents/MMELocationManager.m
+++ b/MapboxMobileEvents/MMELocationManager.m
@@ -9,6 +9,7 @@ static const NSTimeInterval MMELocationManagerHibernationTimeout = 300.0;
 static const NSTimeInterval MMELocationManagerHibernationPollInterval = 5.0;
 
 const CLLocationDistance MMELocationManagerDistanceFilter = 5.0;
+const CLLocationDistance MMERadiusAccuracyMax = 300.0;
 
 NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegionIdentifier.fence.center";
 
@@ -181,7 +182,7 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
     if (location.speed > 0.0) {
         [self startBackgroundTimeoutTimer];
     }
-    if ([self.locationManager.monitoredRegions anyObject] == nil || location.horizontalAccuracy < self.configuration.locationManagerHibernationRadius) {
+    if ([self.locationManager.monitoredRegions anyObject] == nil || location.horizontalAccuracy < MMERadiusAccuracyMax) {
         [self establishRegionMonitoringForLocation:location];
     }
     if ([self.delegate respondsToSelector:@selector(locationManager:didUpdateLocations:)]) {

--- a/MapboxMobileEvents/MMELocationManager.m
+++ b/MapboxMobileEvents/MMELocationManager.m
@@ -9,6 +9,7 @@ static const NSTimeInterval MMELocationManagerHibernationTimeout = 300.0;
 static const NSTimeInterval MMELocationManagerHibernationPollInterval = 5.0;
 
 const CLLocationDistance MMELocationManagerDistanceFilter = 5.0;
+const CLLocationDistance MMERadiusAccuracyMax = 300.0;
 
 NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegionIdentifier.fence.center";
 
@@ -183,7 +184,7 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
     if (location.speed > 0.0) {
         [self startBackgroundTimeoutTimer];
     }
-    if ([self.locationManager.monitoredRegions anyObject] == nil || location.horizontalAccuracy < self.configuration.locationManagerHibernationRadius) {
+    if ([self.locationManager.monitoredRegions anyObject] == nil || location.horizontalAccuracy < MMERadiusAccuracyMax) {
         [self establishRegionMonitoringForLocation:location];
     }
     if ([self.delegate respondsToSelector:@selector(locationManager:didUpdateLocations:)]) {

--- a/MapboxMobileEventsTests/MMEEventsManagerTests.mm
+++ b/MapboxMobileEventsTests/MMEEventsManagerTests.mm
@@ -13,6 +13,7 @@
 #import "MMEUIApplicationWrapperFake.h"
 #import "CLLocation+MMEMobileEvents.h"
 #import "MMEUIApplicationWrapper.h"
+#import "MMEEventsService.h"
 
 using namespace Cedar::Matchers;
 using namespace Cedar::Doubles;
@@ -72,6 +73,28 @@ describe(@"MMEEventsManager", ^{
     
     it(@"sets common event data", ^{
         eventsManager.commonEventData should_not be_nil;
+    });
+    
+    describe(@"- setConfiguration", ^{
+        beforeEach(^{
+            eventsManager.configuration = [MMEEventsService.sharedService configuration];
+        });
+
+        it(@"should set the radius for configuration", ^{
+            eventsManager.configuration.locationManagerHibernationRadius should_not equal(0);
+        });
+        
+        it(@"should set the eventFlushCountThreshold", ^{
+            eventsManager.configuration.eventFlushCountThreshold should_not equal(0);
+        });
+        
+        it(@"should set the eventFlushSecondsThreshold", ^{
+            eventsManager.configuration.eventFlushSecondsThreshold should_not equal(0);
+        });
+        
+        it(@"should set the instanceIdentifierRotationTimeInterval", ^{
+            eventsManager.configuration.instanceIdentifierRotationTimeInterval should_not equal(0);
+        });
     });
     
     describe(@"- setAccessToken", ^{

--- a/MapboxMobileEventsTests/MMELocationManagerTests.mm
+++ b/MapboxMobileEventsTests/MMELocationManagerTests.mm
@@ -2,6 +2,8 @@
 #import "MMELocationManager.h"
 #import "MMEDependencyManager.h"
 #import "MMEUIApplicationWrapper.h"
+#import "MMEEventsConfiguration.h"
+#import "MMEEventsService.h"
 #import <CoreLocation/CoreLocation.h>
 
 using namespace Cedar::Matchers;
@@ -26,8 +28,10 @@ describe(@"MMELocationManager", ^{
     
     __block MMELocationManager *locationManager;
     __block CLLocationManager *locationManagerInstance;
+    __block MMEEventsConfiguration *configuration;
     
     beforeEach(^{
+        configuration = [MMEEventsService.sharedService configuration];
         locationManagerInstance = [[CLLocationManager alloc] init];
         spy_on(locationManagerInstance);
         // Even with the stub on UIBackgroundModes in test setup below, it is not safe to actually call `setAllowsBackgroundLocationUpdates:` in tests
@@ -387,7 +391,7 @@ describe(@"MMELocationManager", ^{
             CLLocation *accurateLocation = [[CLLocation alloc] initWithCoordinate:CLLocationCoordinate2DMake(0, 0) altitude:0 horizontalAccuracy:0 verticalAccuracy:0 course:0 speed:0.0 timestamp:[NSDate date]];
             CLLocation *inaccurateLocation = [[CLLocation alloc] initWithCoordinate:CLLocationCoordinate2DMake(0, 0) altitude:0 horizontalAccuracy:99999 verticalAccuracy:0 course:0 speed:0.0 timestamp:[NSDate date]];
             CLLocation *movingLocation = [[CLLocation alloc] initWithCoordinate:CLLocationCoordinate2DMake(0, 0) altitude:0 horizontalAccuracy:0 verticalAccuracy:0 course:0 speed:100.0 timestamp:[NSDate date]];
-            CLRegion *expectedRegion = [[CLCircularRegion alloc] initWithCenter:CLLocationCoordinate2DMake(0, 0) radius:MMELocationManagerHibernationRadius identifier:MMELocationManagerRegionIdentifier];
+            CLRegion *expectedRegion = [[CLCircularRegion alloc] initWithCenter:CLLocationCoordinate2DMake(0, 0) radius: configuration.locationManagerHibernationRadius identifier:MMELocationManagerRegionIdentifier];
             
             beforeEach(^{
                 spy_on([CLLocationManager class]);

--- a/resources/Info.plist
+++ b/resources/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.1</string>
+	<string>0.4.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSHumanReadableCopyright</key>


### PR DESCRIPTION
- Creates new class MMEEventsService to manage the creation and distribution of MMEEventsConfiguration objects/configurations.
- Expands MMEEventsConfiguration to include a variable hibernation radius configuration and potentially additional configurations in the future. A user may access the variable radius by setting both "MMEEventsProfile" (with the appropriate key "VariableGeofence") and "MMEGeofenceRadius" with a desired radius (within a range we've set) in the applications plist. If "MMEEventsProfile" is set in plist without choosing a radius then a median radius will be the default. 
- Modifies MMELocationManager and MMEEventsManager to use MMEEventsService configuration
- Adds and repairs cedar tests