### PR TITLE
Switch to @available for version checking

### DIFF
--- a/MapboxMobileEvents/MMEEventsManager.m
+++ b/MapboxMobileEvents/MMEEventsManager.m
@@ -73,12 +73,9 @@
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(pauseOrResumeMetricsCollectionIfRequired) name:UIApplicationDidEnterBackgroundNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(pauseOrResumeMetricsCollectionIfRequired) name:UIApplicationDidBecomeActiveNotification object:nil];
     
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunguarded-availability"
-    if (&NSProcessInfoPowerStateDidChangeNotification != NULL) {
+    if (@available(iOS 9.0, *)) {
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(pauseOrResumeMetricsCollectionIfRequired) name:NSProcessInfoPowerStateDidChangeNotification object:nil];
     }
-#pragma clang diagnostic pop
     
     self.paused = YES;
     

--- a/MapboxMobileEvents/MMELocationManager.m
+++ b/MapboxMobileEvents/MMELocationManager.m
@@ -73,12 +73,8 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
     
     CLAuthorizationStatus authorizationStatus = [CLLocationManager authorizationStatus];
     if (authorizationStatus == kCLAuthorizationStatusAuthorizedWhenInUse && self.hostAppHasBackgroundCapability) {
-        // On iOS 9 and above also allow background location updates
-        if ([self.locationManager respondsToSelector:@selector(allowsBackgroundLocationUpdates)]) {
-            #pragma clang diagnostic push
-            #pragma clang diagnostic ignored "-Wunguarded-availability"
-                self.locationManager.allowsBackgroundLocationUpdates = self.isMetricsEnabledForInUsePermissions;
-            #pragma clang diagnostic pop
+        if (@available(iOS 9.0, *)) {
+            self.locationManager.allowsBackgroundLocationUpdates = self.isMetricsEnabledForInUsePermissions;
         }
     }
 }
@@ -103,11 +99,8 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
         if (authorizedAlways && self.hostAppHasBackgroundCapability) {
             [self.locationManager startMonitoringSignificantLocationChanges];
             [self startBackgroundTimeoutTimer];
-            if ([self.locationManager respondsToSelector:@selector(allowsBackgroundLocationUpdates)]) {
-                #pragma clang diagnostic push
-                #pragma clang diagnostic ignored "-Wunguarded-availability"
-                    self.locationManager.allowsBackgroundLocationUpdates = YES;
-                #pragma clang diagnostic pop
+            if (@available(iOS 9.0, *)) {
+                self.locationManager.allowsBackgroundLocationUpdates = YES;
             }
         }
           
@@ -117,11 +110,8 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
         // permissions involve navigation where a user would want and expect the app to be running / navigating
         // even if it is not in the foreground
         if (authorizationStatus == kCLAuthorizationStatusAuthorizedWhenInUse && self.hostAppHasBackgroundCapability) {
-            if ([self.locationManager respondsToSelector:@selector(allowsBackgroundLocationUpdates)]) {
-                #pragma clang diagnostic push
-                #pragma clang diagnostic ignored "-Wunguarded-availability"
-                    self.locationManager.allowsBackgroundLocationUpdates = self.isMetricsEnabledForInUsePermissions;
-                #pragma clang diagnostic pop
+            if (@available(iOS 9.0, *)) {
+                self.locationManager.allowsBackgroundLocationUpdates = self.isMetricsEnabledForInUsePermissions;
             }
         }
         


### PR DESCRIPTION
Simplifies the iOS availability checks by switching to `@available`. This requires Xcode 9.x, which is standard across our projects (and hopefully the vast majority of projects in general).

This fixes warnings prompted by a consumer project requiring iOS 9 or newer:

![screen shot 2018-04-27 at 1 13 42 pm](https://user-images.githubusercontent.com/1198851/39378708-2df3ca68-4a27-11e8-894a-df71341d5692.png)

/cc @rclee @akitchen @1ec5 