### PR TITLE
Refactor timer code into separate utility class

### DIFF
--- a/MapboxMobileEvents.xcodeproj/project.pbxproj
+++ b/MapboxMobileEvents.xcodeproj/project.pbxproj
@@ -141,6 +141,8 @@
 		AC611F281FCDED2F00ABBF6D /* MMEEventLogReportViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = AC611F261FCDED2F00ABBF6D /* MMEEventLogReportViewController.m */; };
 		ACB6F21E1F7BF71B0032A916 /* MMELocationManagerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACB6F21D1F7BF71B0032A916 /* MMELocationManagerTests.mm */; };
 		ACD86DA01F96A77700DD2A8D /* MMEAPIClientTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACD86D9F1F96A77700DD2A8D /* MMEAPIClientTests.mm */; };
+		ACDB23FD20F416D100D84DB1 /* MMEBackgroundLocationServiceTimeoutHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = ACDB23FB20F416D000D84DB1 /* MMEBackgroundLocationServiceTimeoutHandler.h */; };
+		ACDB23FE20F416D100D84DB1 /* MMEBackgroundLocationServiceTimeoutHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = ACDB23FC20F416D000D84DB1 /* MMEBackgroundLocationServiceTimeoutHandler.m */; };
 		ACE4F01A1FD6102100035880 /* MMEUINavigation.h in Headers */ = {isa = PBXBuildFile; fileRef = ACE4F0181FD6102100035880 /* MMEUINavigation.h */; };
 		ACE4F01B1FD6102100035880 /* MMEUINavigation.m in Sources */ = {isa = PBXBuildFile; fileRef = ACE4F0191FD6102100035880 /* MMEUINavigation.m */; };
 /* End PBXBuildFile section */
@@ -292,6 +294,8 @@
 		AC611F261FCDED2F00ABBF6D /* MMEEventLogReportViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MMEEventLogReportViewController.m; sourceTree = "<group>"; };
 		ACB6F21D1F7BF71B0032A916 /* MMELocationManagerTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MMELocationManagerTests.mm; sourceTree = "<group>"; };
 		ACD86D9F1F96A77700DD2A8D /* MMEAPIClientTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MMEAPIClientTests.mm; sourceTree = "<group>"; };
+		ACDB23FB20F416D000D84DB1 /* MMEBackgroundLocationServiceTimeoutHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MMEBackgroundLocationServiceTimeoutHandler.h; sourceTree = "<group>"; };
+		ACDB23FC20F416D000D84DB1 /* MMEBackgroundLocationServiceTimeoutHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MMEBackgroundLocationServiceTimeoutHandler.m; sourceTree = "<group>"; };
 		ACE4F0181FD6102100035880 /* MMEUINavigation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MMEUINavigation.h; sourceTree = "<group>"; };
 		ACE4F0191FD6102100035880 /* MMEUINavigation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MMEUINavigation.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -395,6 +399,8 @@
 				40FB43761EF9EA7800EC5BC0 /* MMEEventsConfiguration.m */,
 				40C9E2791EA542BC00744FE7 /* MMEEventsManager.h */,
 				40C9E27A1EA542BC00744FE7 /* MMEEventsManager.m */,
+				ACDB23FB20F416D000D84DB1 /* MMEBackgroundLocationServiceTimeoutHandler.h */,
+				ACDB23FC20F416D000D84DB1 /* MMEBackgroundLocationServiceTimeoutHandler.m */,
 				40C9E27D1EA5473F00744FE7 /* MMELocationManager.h */,
 				40C9E27E1EA5473F00744FE7 /* MMELocationManager.m */,
 				40FB437A1EFAFAE900EC5BC0 /* MMETimerManager.h */,
@@ -578,6 +584,7 @@
 				40F133541F20051E007B4096 /* NSData+MMEGZIP.h in Headers */,
 				40AE58431EA6C86C0046B437 /* MMEUIApplicationWrapper.h in Headers */,
 				40C611871F18319000E30A6C /* TSKPinningValidatorCallback.h in Headers */,
+				ACDB23FD20F416D100D84DB1 /* MMEBackgroundLocationServiceTimeoutHandler.h in Headers */,
 				40C611471F18319000E30A6C /* configuration_utils.h in Headers */,
 				40AE585A1EA9373F0046B437 /* MMEUniqueIdentifier.h in Headers */,
 				409115351F16BCD200F4250B /* MMECategoryLoader.h in Headers */,
@@ -797,6 +804,7 @@
 				40C611801F18319000E30A6C /* TrustKit.m in Sources */,
 				40C9E27C1EA542BC00744FE7 /* MMEEventsManager.m in Sources */,
 				40AE58571EA932DB0046B437 /* MMEConstants.m in Sources */,
+				ACDB23FE20F416D100D84DB1 /* MMEBackgroundLocationServiceTimeoutHandler.m in Sources */,
 				40AE586A1EA953970046B437 /* CLLocation+MMEMobileEvents.m in Sources */,
 				40AE58441EA6C86C0046B437 /* MMEUIApplicationWrapper.m in Sources */,
 				4036EFBF1ED37D56009C40BA /* MMEEventLogger.m in Sources */,

--- a/MapboxMobileEvents/MMEBackgroundLocationServiceTimeoutHandler.h
+++ b/MapboxMobileEvents/MMEBackgroundLocationServiceTimeoutHandler.h
@@ -3,7 +3,7 @@
 @class MMEBackgroundLocationServiceTimeoutHandler;
 @protocol MMEUIApplicationWrapper;
 
-@protocol MMEBackgroundLocationServiceTimeoutHandlerDelegate
+@protocol MMEBackgroundLocationServiceTimeoutDelegate
 - (BOOL)timeoutHandlerShouldCheckForTimeout:(MMEBackgroundLocationServiceTimeoutHandler *)handler;
 - (void)timeoutHandlerDidTimeout:(MMEBackgroundLocationServiceTimeoutHandler *)handler;
 - (void)timeoutHandlerBackgroundTaskDidExpire:(MMEBackgroundLocationServiceTimeoutHandler *)handler;
@@ -12,7 +12,7 @@
 
 @interface MMEBackgroundLocationServiceTimeoutHandler: NSObject
 
-@property (nonatomic, weak) id<MMEBackgroundLocationServiceTimeoutHandlerDelegate> delegate;
+@property (nonatomic, weak) id<MMEBackgroundLocationServiceTimeoutDelegate> delegate;
 @property (nonatomic, readonly) NSTimer *timer;
 - (instancetype)initWithApplication:(id<MMEUIApplicationWrapper>)application;
 - (void)startTimer;

--- a/MapboxMobileEvents/MMEBackgroundLocationServiceTimeoutHandler.h
+++ b/MapboxMobileEvents/MMEBackgroundLocationServiceTimeoutHandler.h
@@ -1,0 +1,18 @@
+#import <Foundation/Foundation.h>
+
+@class MMEBackgroundLocationServiceTimeoutHandler;
+@protocol MMEUIApplicationWrapper;
+
+@protocol MMEBackgroundLocationServiceTimeoutHandlerDelegate
+- (BOOL)timeoutHandlerShouldCheckForTimeout:(MMEBackgroundLocationServiceTimeoutHandler *)handler;
+- (void)timeoutHandlerDidTimeout:(MMEBackgroundLocationServiceTimeoutHandler *)handler;
+@end
+
+@interface MMEBackgroundLocationServiceTimeoutHandler: NSObject
+
+@property (nonatomic, weak) id<MMEBackgroundLocationServiceTimeoutHandlerDelegate> delegate;
+- (instancetype)initWithApplication:(id<MMEUIApplicationWrapper>)application;
+- (void)startBackgroundTimeoutTimer;
+- (void)stopBackgroundTimeoutTimer;
+@end
+

--- a/MapboxMobileEvents/MMEBackgroundLocationServiceTimeoutHandler.h
+++ b/MapboxMobileEvents/MMEBackgroundLocationServiceTimeoutHandler.h
@@ -6,13 +6,16 @@
 @protocol MMEBackgroundLocationServiceTimeoutHandlerDelegate
 - (BOOL)timeoutHandlerShouldCheckForTimeout:(MMEBackgroundLocationServiceTimeoutHandler *)handler;
 - (void)timeoutHandlerDidTimeout:(MMEBackgroundLocationServiceTimeoutHandler *)handler;
+- (void)timeoutHandlerBackgroundTaskDidExpire:(MMEBackgroundLocationServiceTimeoutHandler *)handler;
+
 @end
 
 @interface MMEBackgroundLocationServiceTimeoutHandler: NSObject
 
 @property (nonatomic, weak) id<MMEBackgroundLocationServiceTimeoutHandlerDelegate> delegate;
+@property (nonatomic, readonly) NSTimer *timer;
 - (instancetype)initWithApplication:(id<MMEUIApplicationWrapper>)application;
-- (void)startBackgroundTimeoutTimer;
-- (void)stopBackgroundTimeoutTimer;
+- (void)startTimer;
+- (void)stopTimer;
 @end
 

--- a/MapboxMobileEvents/MMEBackgroundLocationServiceTimeoutHandler.m
+++ b/MapboxMobileEvents/MMEBackgroundLocationServiceTimeoutHandler.m
@@ -26,7 +26,7 @@ static const NSTimeInterval MMELocationManagerHibernationPollInterval = 5.0;
 }
 
 - (void)timeoutAllowedCheck:(NSTimer *)timer {
-    id<MMEBackgroundLocationServiceTimeoutHandlerDelegate> delegate = self.delegate;
+    id<MMEBackgroundLocationServiceTimeoutDelegate> delegate = self.delegate;
 
     if (!delegate) {
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -55,7 +55,9 @@ static const NSTimeInterval MMELocationManagerHibernationPollInterval = 5.0;
 
 - (void)startTimer {
     if (self.timer) {
-        return;
+        // Changed from return, to ensure we get a new background task. This matches
+        // the previous behaviour (prior to refactoring)
+        [self stopTimer];
     }
 
     __weak __typeof__(self) weakself = self;

--- a/MapboxMobileEvents/MMEBackgroundLocationServiceTimeoutHandler.m
+++ b/MapboxMobileEvents/MMEBackgroundLocationServiceTimeoutHandler.m
@@ -1,0 +1,82 @@
+#import "MMEBackgroundLocationServiceTimeoutHandler.h"
+#import "MMEUIApplicationWrapper.h"
+
+static const NSTimeInterval MMELocationManagerHibernationTimeout = 300.0;
+static const NSTimeInterval MMELocationManagerHibernationPollInterval = 5.0;
+
+@interface MMEBackgroundLocationServiceTimeoutHandler ()
+
+@property (nonatomic) id<MMEUIApplicationWrapper> application;
+@property (nonatomic) NSDate *backgroundLocationServiceTimeoutAllowedDate;
+@property (nonatomic) NSTimer *backgroundLocationServiceTimeoutTimer;
+@property (nonatomic) UIBackgroundTaskIdentifier backgroundLocationServiceTimeoutTaskId;
+
+@end
+
+#pragma mark - MMEBackgroundLocationServiceTimeoutHandler
+
+@implementation MMEBackgroundLocationServiceTimeoutHandler
+
+- (instancetype)initWithApplication:(id<MMEUIApplicationWrapper>)application {
+    self = [super init];
+    if (self) {
+        _application = application;
+    }
+    return self;
+}
+
+- (void)timeoutAllowedCheck:(NSTimer *)timer {
+    id<MMEBackgroundLocationServiceTimeoutHandlerDelegate> delegate = self.delegate;
+
+    if (!delegate) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self stopBackgroundTimeoutTimer];
+        });
+        return;
+    }
+
+    if (![delegate timeoutHandlerShouldCheckForTimeout:self]) {
+        self.backgroundLocationServiceTimeoutAllowedDate = [[NSDate date] dateByAddingTimeInterval:MMELocationManagerHibernationTimeout];
+        return;
+    }
+
+    if (!self.backgroundLocationServiceTimeoutAllowedDate) {
+        return;
+    }
+
+    NSTimeInterval timeIntervalSinceTimeoutAllowed = [[NSDate date] timeIntervalSinceDate:self.backgroundLocationServiceTimeoutAllowedDate];
+    if (timeIntervalSinceTimeoutAllowed > 0) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self stopBackgroundTimeoutTimer];
+            [delegate timeoutHandlerDidTimeout:self];
+        });
+    }
+}
+
+- (void)startBackgroundTimeoutTimer {
+    if (self.backgroundLocationServiceTimeoutTimer) {
+        return;
+    }
+
+    __weak __typeof__(self) weakself = self;
+    NSAssert(self.backgroundLocationServiceTimeoutTaskId == UIBackgroundTaskInvalid, @"Background task Id should be invalid");
+    self.backgroundLocationServiceTimeoutTaskId = [self.application beginBackgroundTaskWithExpirationHandler:^{
+        [weakself stopBackgroundTimeoutTimer];
+    }];
+
+    self.backgroundLocationServiceTimeoutAllowedDate = [[NSDate date] dateByAddingTimeInterval:MMELocationManagerHibernationTimeout];
+    self.backgroundLocationServiceTimeoutTimer = [NSTimer scheduledTimerWithTimeInterval:MMELocationManagerHibernationPollInterval target:self selector:@selector(timeoutAllowedCheck:) userInfo:nil repeats:YES];
+}
+
+- (void)stopBackgroundTimeoutTimer {
+    if (UIBackgroundTaskInvalid != self.backgroundLocationServiceTimeoutTaskId) {
+        [self.application endBackgroundTask:self.backgroundLocationServiceTimeoutTaskId];
+        self.backgroundLocationServiceTimeoutTaskId = UIBackgroundTaskInvalid;
+    }
+
+    [self.backgroundLocationServiceTimeoutTimer invalidate];
+    self.backgroundLocationServiceTimeoutTimer = nil;
+    self.backgroundLocationServiceTimeoutAllowedDate = nil;
+}
+
+@end

--- a/MapboxMobileEvents/MMELocationManager.m
+++ b/MapboxMobileEvents/MMELocationManager.m
@@ -25,6 +25,7 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
 @implementation MMELocationManager
 
 - (void)dealloc {
+    _locationManager.delegate = nil;
     [self stopBackgroundTimeoutTimer];
 }
 
@@ -92,6 +93,15 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
 }
 
 #pragma mark - Utilities
+
+- (void)setLocationManager:(CLLocationManager *)locationManager {
+    if (locationManager == _locationManager) {
+        return;
+    }
+
+    _locationManager.delegate = nil;
+    _locationManager = locationManager;
+}
 
 - (void)configurePassiveLocationManager {
     self.locationManager.delegate = self;

--- a/MapboxMobileEvents/MMELocationManager.m
+++ b/MapboxMobileEvents/MMELocationManager.m
@@ -11,7 +11,7 @@ const CLLocationDistance MMERadiusAccuracyMax = 300.0;
 
 NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegionIdentifier.fence.center";
 
-@interface MMELocationManager () <CLLocationManagerDelegate, MMEBackgroundLocationServiceTimeoutHandlerDelegate>
+@interface MMELocationManager () <CLLocationManagerDelegate, MMEBackgroundLocationServiceTimeoutDelegate>
 
 @property (nonatomic) id<MMEUIApplicationWrapper> application;
 @property (nonatomic) CLLocationManager *locationManager;
@@ -209,7 +209,7 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
     }
 }
 
-#pragma mark - MMEBackgroundLocationServiceTimeoutHandlerDelegate
+#pragma mark - MMEBackgroundLocationServiceTimeoutDelegate
 
 - (BOOL)timeoutHandlerShouldCheckForTimeout:(__unused MMEBackgroundLocationServiceTimeoutHandler *)handler {
     return self.isUpdatingLocation && (self.application.applicationState == UIApplicationStateBackground);
@@ -226,6 +226,8 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
 - (void)timeoutHandlerBackgroundTaskDidExpire:(__unused MMEBackgroundLocationServiceTimeoutHandler *)handler {
     // Do we need a delegate method here (i.e. do we need an event for background task expiry?)
     NSAssert(!handler.timer, @"Timer should be nil by this point");
+
+    [self.locationManager stopUpdatingLocation];
 }
 
 

--- a/MapboxMobileEvents/MMELocationManager.m
+++ b/MapboxMobileEvents/MMELocationManager.m
@@ -225,7 +225,7 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
 
 - (void)timeoutHandlerBackgroundTaskDidExpire:(__unused MMEBackgroundLocationServiceTimeoutHandler *)handler {
     // Do we need a delegate method here (i.e. do we need an event for background task expiry?)
-    NSAssert(!self.timer, @"Timer should be nil by this point");
+    NSAssert(!handler.timer, @"Timer should be nil by this point");
 }
 
 

--- a/MapboxMobileEvents/MMELocationManager.m
+++ b/MapboxMobileEvents/MMELocationManager.m
@@ -26,7 +26,7 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
 
 - (void)dealloc {
     _locationManager.delegate = nil;
-    [self stopBackgroundTimeoutTimer];
+    [_backgroundLocationServiceTimeoutTimerWrapper stopTimer];
 }
 
 - (instancetype)init {
@@ -151,11 +151,11 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
 }
 
 - (void)startBackgroundTimeoutTimer {
-    [self.backgroundLocationServiceTimeoutTimerWrapper startBackgroundTimeoutTimer];
+    [self.backgroundLocationServiceTimeoutTimerWrapper startTimer];
 }
 
 - (void)stopBackgroundTimeoutTimer {
-    [self.backgroundLocationServiceTimeoutTimerWrapper stopBackgroundTimeoutTimer];
+    [self.backgroundLocationServiceTimeoutTimerWrapper stopTimer];
 }
 
 - (void)establishRegionMonitoringForLocation:(CLLocation *)location {
@@ -201,6 +201,9 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
 }
 
 - (void)locationManagerDidPauseLocationUpdates:(CLLocationManager *)locationManager {
+    // TODO: Should we stop the background timer here for completeness?
+//  [self stopBackgroundTimeoutTimer];
+
     if ([self.delegate respondsToSelector:@selector(locationManagerBackgroundLocationUpdatesDidAutomaticallyPause:)]) {
         [self.delegate locationManagerBackgroundLocationUpdatesDidAutomaticallyPause:self];
     }
@@ -219,5 +222,12 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
 
     [self.locationManager stopUpdatingLocation];
 }
+
+- (void)timeoutHandlerBackgroundTaskDidExpire:(__unused MMEBackgroundLocationServiceTimeoutHandler *)handler {
+    // Do we need a delegate method here (i.e. do we need an event for background task expiry?)
+    NSAssert(!self.timer, @"Timer should be nil by this point");
+}
+
+
 
 @end

--- a/MapboxMobileEvents/MMENamespacedDependencies.h
+++ b/MapboxMobileEvents/MMENamespacedDependencies.h
@@ -14,6 +14,10 @@
 #define MMEAPIClient __NS_SYMBOL(MMEAPIClient)
 #endif
 
+#ifndef MMEBackgroundLocationServiceTimeoutHandler
+#define MMEBackgroundLocationServiceTimeoutHandler __NS_SYMBOL(MMEBackgroundLocationServiceTimeoutHandler)
+#endif
+
 #ifndef MMECategoryLoader
 #define MMECategoryLoader __NS_SYMBOL(MMECategoryLoader)
 #endif

--- a/MapboxMobileEvents/MMENamespacedDependencies.h
+++ b/MapboxMobileEvents/MMENamespacedDependencies.h
@@ -192,6 +192,10 @@
 #define MMEAPIClient __NS_SYMBOL(MMEAPIClient)
 #endif
 
+#ifndef MMEBackgroundLocationServiceTimeoutHandlerDelegate
+#define MMEBackgroundLocationServiceTimeoutHandlerDelegate __NS_SYMBOL(MMEBackgroundLocationServiceTimeoutHandlerDelegate)
+#endif
+
 #ifndef MMELocationManager
 #define MMELocationManager __NS_SYMBOL(MMELocationManager)
 #endif
@@ -588,16 +592,16 @@
 #define MMELoggerShareableHTML __NS_SYMBOL(MMELoggerShareableHTML)
 #endif
 
-#ifndef kMMEReachabilityChangedNotification
-#define kMMEReachabilityChangedNotification __NS_SYMBOL(kMMEReachabilityChangedNotification)
-#endif
-
 #ifndef MMELocationManagerDistanceFilter
 #define MMELocationManagerDistanceFilter __NS_SYMBOL(MMELocationManagerDistanceFilter)
 #endif
 
 #ifndef MMERadiusAccuracyMax
 #define MMERadiusAccuracyMax __NS_SYMBOL(MMERadiusAccuracyMax)
+#endif
+
+#ifndef kMMEReachabilityChangedNotification
+#define kMMEReachabilityChangedNotification __NS_SYMBOL(kMMEReachabilityChangedNotification)
 #endif
 
 #ifndef MMELocationManagerRegionIdentifier

--- a/MapboxMobileEvents/MMENamespacedDependencies.h
+++ b/MapboxMobileEvents/MMENamespacedDependencies.h
@@ -192,8 +192,8 @@
 #define MMEAPIClient __NS_SYMBOL(MMEAPIClient)
 #endif
 
-#ifndef MMEBackgroundLocationServiceTimeoutHandlerDelegate
-#define MMEBackgroundLocationServiceTimeoutHandlerDelegate __NS_SYMBOL(MMEBackgroundLocationServiceTimeoutHandlerDelegate)
+#ifndef MMEBackgroundLocationServiceTimeoutDelegate
+#define MMEBackgroundLocationServiceTimeoutDelegate __NS_SYMBOL(MMEBackgroundLocationServiceTimeoutDelegate)
 #endif
 
 #ifndef MMELocationManager


### PR DESCRIPTION
This PR moves the timer code out of `MMELocationManager` to avoid circular references.
It also ensures that the location manager's `delegate` property is set to nil to avoid a crash. (`CLLocationManager`'s `delegate` property is declared as `assign` so needs to be manually `nil`'d.)

We may want to move this secondary bug fix into a separate PR, so we merge faster, but both of these changes are related to circular references so seemed appropriate.

@rclee I wanted to get this PR in, even though we're still discussing the related telemetry crash at https://github.com/mapbox/mapbox-events-ios/issues/50. 

Update: ~Please note,  there is a similar change we need to make in https://github.com/mapbox/mapbox-gl-native, both of these bugs could account for the above crash. (I'll update this PR with that change when I create it.)~

Update 2: The introduction of a custom location manager (via the `MGLCLLocationManager` protocol in https://github.com/mapbox/mapbox-gl-native/pull/12013) does away for the related change I mention above).