### PR TITLE
Set location manager's delegate to nil before deallocating

### DIFF
--- a/MapboxMobileEvents/MMELocationManager.m
+++ b/MapboxMobileEvents/MMELocationManager.m
@@ -27,6 +27,10 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
 
 @implementation MMELocationManager
 
+- (void)dealloc {
+    _locationManager.delegate = nil;
+}
+
 - (instancetype)init {
     self = [super init];
     if (self) {
@@ -45,6 +49,7 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
     if ([self isUpdatingLocation]) {
         return;
     }
+
     self.locationManager = [[MMEDependencyManager sharedManager] locationManagerInstance];
     [self configurePassiveLocationManager];
     [self startLocationServices];
@@ -62,6 +67,13 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
         [self stopMonitoringRegions];
         self.locationManager = nil;
     }
+}
+
+- (void)setLocationManager:(CLLocationManager *)locationManager {
+    id<CLLocationManagerDelegate> delegate = _locationManager.delegate;
+    _locationManager.delegate = nil;
+    _locationManager = locationManager;
+    _locationManager.delegate = delegate;
 }
 
 - (void)stopMonitoringRegions {


### PR DESCRIPTION
`CLLocationManager`'s `delegate` property is declared as `assign` - so needs to be nil'd whenever the instance containing the location manager is about to be deallocated.

This may partially address https://github.com/mapbox/mapbox-events-ios/issues/54 and https://github.com/mapbox/mapbox-events-ios/issues/50 - though it also requires a related change in `MGLMapView`.
