### PR TITLE
allow the vision namespace for vision sdk events.  

### DIFF
--- a/MapboxMobileEvents/MMEConstants.h
+++ b/MapboxMobileEvents/MMEConstants.h
@@ -69,6 +69,7 @@ extern NSString * const MMEEventSDKIdentifier;
 extern NSString * const MMEEventSDKVersion;
 extern NSString * const MMEEventKeyLocalDebugDescription;
 extern NSString * const MMENavigationEventPrefix;
+extern NSString * const MMEVisionEventPrefix;
 extern NSString * const MMEEventTypeNavigationDepart;
 extern NSString * const MMEEventTypeNavigationArrive;
 extern NSString * const MMEEventTypeNavigationCancel;

--- a/MapboxMobileEvents/MMEConstants.m
+++ b/MapboxMobileEvents/MMEConstants.m
@@ -67,6 +67,7 @@ NSString * const MMEEventKeyAltitude = @"altitude";
 NSString * const MMEEventSDKIdentifier = @"sdkIdentifier";
 NSString * const MMEEventSDKVersion = @"sdkVersion";
 NSString * const MMENavigationEventPrefix = @"navigation.";
+NSString * const MMEVisionEventPrefix = @"vision.";
 NSString * const MMEEventTypeNavigationDepart = @"navigation.depart";
 NSString * const MMEEventTypeNavigationArrive = @"navigation.arrive";
 NSString * const MMEEventTypeNavigationCancel = @"navigation.cancel";

--- a/MapboxMobileEvents/MMEEvent.h
+++ b/MapboxMobileEvents/MMEEvent.h
@@ -14,6 +14,7 @@
 + (instancetype)mapTapEventWithDateString:(NSString *)dateString attributes:(NSDictionary *)attributes;
 + (instancetype)mapDragEndEventWithDateString:(NSString *)dateString attributes:(NSDictionary *)attributes;
 + (instancetype)navigationEventWithName:(NSString *)name attributes:(NSDictionary *)attributes;
++ (instancetype)visionEventWithName:(NSString *)name attributes:(NSDictionary *)attributes;
 + (instancetype)debugEventWithAttributes:(NSDictionary *)attributes;
 
 @end

--- a/MapboxMobileEvents/MMEEvent.m
+++ b/MapboxMobileEvents/MMEEvent.m
@@ -90,6 +90,13 @@
     return navigationEvent;
 }
 
++ (instancetype)visionEventWithName:(NSString *)name attributes:(NSDictionary *)attributes {
+    MMEEvent *visionEvent = [[MMEEvent alloc] init];
+    visionEvent.name = name;
+    visionEvent.attributes = attributes;
+    return visionEvent;
+}
+
 + (instancetype)debugEventWithAttributes:(NSDictionary *)attributes {
     MMEEvent *debugEvent = [[MMEEvent alloc] init];
     debugEvent.name = MMEEventTypeLocalDebug;

--- a/MapboxMobileEvents/MMEEventsManager.m
+++ b/MapboxMobileEvents/MMEEventsManager.m
@@ -299,7 +299,11 @@
     if ([name hasPrefix:MMENavigationEventPrefix]) {
         event = [MMEEvent navigationEventWithName:name attributes:attributes];
     }
-    
+
+    if ([name hasPrefix:MMEVisionEventPrefix]) {
+        event = [MMEEvent visionEventWithName:name attributes:attributes];
+    }
+
     if (event) {
         [self pushDebugEventWithAttributes:@{MMEDebugEventType: MMEDebugEventTypePush,
                                              MMEEventKeyLocalDebugDescription: [NSString stringWithFormat:@"Pushing event: %@", event]}];

--- a/MapboxMobileEvents/MMENamespacedDependencies.h
+++ b/MapboxMobileEvents/MMENamespacedDependencies.h
@@ -548,6 +548,10 @@
 #define MMENavigationEventPrefix __NS_SYMBOL(MMENavigationEventPrefix)
 #endif
 
+#ifndef MMEVisionEventPrefix
+#define MMEVisionEventPrefix __NS_SYMBOL(MMEVisionEventPrefix)
+#endif
+
 #ifndef MMEEventTypeNavigationDepart
 #define MMEEventTypeNavigationDepart __NS_SYMBOL(MMEEventTypeNavigationDepart)
 #endif

--- a/MapboxMobileEventsTests/MMEEventsManagerTests.mm
+++ b/MapboxMobileEventsTests/MMEEventsManagerTests.mm
@@ -740,6 +740,20 @@ describe(@"MMEEventsManager", ^{
                 });
             });
             
+            context(@"when a vision event is pushed", ^{
+                __block NSString * visionEventName = @"vision.*";
+                
+                beforeEach(^{
+                    [eventsManager enqueueEventWithName:visionEventName attributes:attributes];
+                });
+                
+                it(@"has the correct event", ^{
+                    MMEEvent *expectedEvent = [MMEEvent navigationEventWithName:visionEventName attributes:attributes];
+                    MMEEvent *event = eventsManager.eventQueue.firstObject;
+                    event should equal(expectedEvent);
+                });
+            });
+            
             context(@"when an unknown event is pushed", ^{
                 beforeEach(^{
                     [eventsManager enqueueEventWithName:@"invalid" attributes:attributes];


### PR DESCRIPTION
follows the same pattern as navigation events.

I've never commit code to this repo. Guidance on next steps, or @rclee or @zugaldia you can run with this from here, that would be appreciated.


cc @rclee @zugaldia  @deniskoronchik @l-r @willwhite 