### PR TITLE
Call completion block on the main queue.

### DIFF
--- a/MapboxMobileEvents/MMEEventsManager.m
+++ b/MapboxMobileEvents/MMEEventsManager.m
@@ -171,6 +171,7 @@
     }
     
     NSArray *events = [self.eventQueue copy];
+    NSUInteger eventsCount = events.count;
     __weak __typeof__(self) weakSelf = self;
     [self.apiClient postEvents:events completionHandler:^(NSError * _Nullable error) {
         __strong __typeof__(weakSelf) strongSelf = weakSelf;
@@ -181,7 +182,7 @@
         } else {
             [strongSelf pushDebugEventWithAttributes:@{MMEDebugEventType: MMEDebugEventTypePost,
                                                        MMEEventKeyLocalDebugDescription: @"post",
-                                                       @"debug.eventsCount": @(events.count)}];
+                                                       @"debug.eventsCount": @(eventsCount)}];
         }
         
         

--- a/MapboxMobileEvents/MMENSURLSessionWrapper.m
+++ b/MapboxMobileEvents/MMENSURLSessionWrapper.m
@@ -28,7 +28,9 @@
     dispatch_async(self.serialQueue, ^{
         __block NSURLSessionDataTask *dataTask = [self.session dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
             if (completionHandler) {
-                completionHandler(data, response, error);
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    completionHandler(data, response, error);
+                });
             }
             dataTask = nil;
         }];


### PR DESCRIPTION
The assumption here is that `processRequest:completionHandler:` is being call on the main thread, and so the completion block should too. Is this a safe assumption? 

/cc @lloydsheng 