### PR TITLE
Fix offline crash

### DIFF
--- a/MapboxMobileEvents/MMEAPIClient.h
+++ b/MapboxMobileEvents/MMEAPIClient.h
@@ -20,8 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)getConfigurationWithCompletionHandler:(nullable void (^)(NSError * _Nullable error, NSData * _Nullable data))completionHandler;
 - (void)reconfigure:(MMEEventsConfiguration *)configuration;
-- (NSError *)statusErrorFromRequest:(nonnull NSURLRequest *)request andHTTPResponse:(nonnull NSHTTPURLResponse *)httpResponse;
-- (NSError *)unexpectedResponseErrorfromRequest:(nonnull NSURLRequest *)request andResponse:(NSURLResponse *)response;
+- (NSError *)statusErrorFromRequest:(NSURLRequest *)request andHTTPResponse:(NSHTTPURLResponse *)httpResponse;
+- (NSError *)unexpectedResponseErrorfromRequest:(NSURLRequest *)request andResponse:(NSURLResponse *)response;
 
 @end
 
@@ -38,8 +38,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)postEvent:(MMEEvent *)event completionHandler:(nullable void (^)(NSError * _Nullable error))completionHandler;
 - (void)postMetadata:(NSArray *)metadata filePaths:(NSArray *)filePaths completionHandler:(nullable void (^)(NSError * _Nullable error))completionHandler;
 - (void)getConfigurationWithCompletionHandler:(nullable void (^)(NSError * _Nullable error, NSData * _Nullable data))completionHandler;
-- (NSError *)statusErrorFromRequest:(nonnull NSURLRequest *)request andHTTPResponse:(nonnull NSHTTPURLResponse *)httpResponse;
-- (NSError *)unexpectedResponseErrorfromRequest:(nonnull NSURLRequest *)request andResponse:(NSURLResponse *)response;
+- (NSError *)statusErrorFromRequest:(NSURLRequest *)request andHTTPResponse:(NSHTTPURLResponse *)httpResponse;
+- (NSError *)unexpectedResponseErrorfromRequest:(NSURLRequest *)request andResponse:(NSURLResponse *)response;
 
 @end
 

--- a/MapboxMobileEvents/MMEAPIClient.h
+++ b/MapboxMobileEvents/MMEAPIClient.h
@@ -20,6 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)getConfigurationWithCompletionHandler:(nullable void (^)(NSError * _Nullable error, NSData * _Nullable data))completionHandler;
 - (void)reconfigure:(MMEEventsConfiguration *)configuration;
+- (NSError *)statusErrorFromRequest:(NSURLRequest *)request andHTTPResponse:(NSHTTPURLResponse *)httpResponse;
+- (NSError *)unexpectedResponseErrorfromRequest:(NSURLRequest *)request andResponse:(NSURLResponse *)response;
 
 @end
 
@@ -36,6 +38,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)postEvent:(MMEEvent *)event completionHandler:(nullable void (^)(NSError * _Nullable error))completionHandler;
 - (void)postMetadata:(NSArray *)metadata filePaths:(NSArray *)filePaths completionHandler:(nullable void (^)(NSError * _Nullable error))completionHandler;
 - (void)getConfigurationWithCompletionHandler:(nullable void (^)(NSError * _Nullable error, NSData * _Nullable data))completionHandler;
+- (NSError *)statusErrorFromRequest:(NSURLRequest *)request andHTTPResponse:(NSHTTPURLResponse *)httpResponse;
+- (NSError *)unexpectedResponseErrorfromRequest:(NSURLRequest *)request andResponse:(NSURLResponse *)response;
 
 @end
 

--- a/MapboxMobileEvents/MMEAPIClient.h
+++ b/MapboxMobileEvents/MMEAPIClient.h
@@ -20,8 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)getConfigurationWithCompletionHandler:(nullable void (^)(NSError * _Nullable error, NSData * _Nullable data))completionHandler;
 - (void)reconfigure:(MMEEventsConfiguration *)configuration;
-- (NSError *)statusErrorFromRequest:(NSURLRequest *)request andHTTPResponse:(NSHTTPURLResponse *)httpResponse;
-- (NSError *)unexpectedResponseErrorfromRequest:(NSURLRequest *)request andResponse:(NSURLResponse *)response;
+- (NSError *)statusErrorFromRequest:(nonnull NSURLRequest *)request andHTTPResponse:(nonnull NSHTTPURLResponse *)httpResponse;
+- (NSError *)unexpectedResponseErrorfromRequest:(nonnull NSURLRequest *)request andResponse:(NSURLResponse *)response;
 
 @end
 
@@ -38,8 +38,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)postEvent:(MMEEvent *)event completionHandler:(nullable void (^)(NSError * _Nullable error))completionHandler;
 - (void)postMetadata:(NSArray *)metadata filePaths:(NSArray *)filePaths completionHandler:(nullable void (^)(NSError * _Nullable error))completionHandler;
 - (void)getConfigurationWithCompletionHandler:(nullable void (^)(NSError * _Nullable error, NSData * _Nullable data))completionHandler;
-- (NSError *)statusErrorFromRequest:(NSURLRequest *)request andHTTPResponse:(NSHTTPURLResponse *)httpResponse;
-- (NSError *)unexpectedResponseErrorfromRequest:(NSURLRequest *)request andResponse:(NSURLResponse *)response;
+- (NSError *)statusErrorFromRequest:(nonnull NSURLRequest *)request andHTTPResponse:(nonnull NSHTTPURLResponse *)httpResponse;
+- (NSError *)unexpectedResponseErrorfromRequest:(nonnull NSURLRequest *)request andResponse:(NSURLResponse *)response;
 
 @end
 

--- a/MapboxMobileEvents/MMEAPIClient.m
+++ b/MapboxMobileEvents/MMEAPIClient.m
@@ -116,6 +116,9 @@ typedef NS_ENUM(NSInteger, MMEErrorCode) {
 #pragma mark - Utilities
 
 - (NSError *)statusErrorFromRequest:(NSURLRequest *)request andHTTPResponse:(NSHTTPURLResponse *)httpResponse {
+    if (!httpResponse) {
+        httpResponse = [[NSHTTPURLResponse alloc] initWithURL:self.baseURL statusCode:0 HTTPVersion:nil headerFields:nil];
+    }
     NSError *statusError = nil;
     if (httpResponse.statusCode >= 400) {
         NSString *descriptionFormat = @"The session data task failed. Original request was: %@";
@@ -131,6 +134,9 @@ typedef NS_ENUM(NSInteger, MMEErrorCode) {
 }
 
 - (NSError *)unexpectedResponseErrorfromRequest:(NSURLRequest *)request andResponse:(NSURLResponse *)response {
+    if (!response) {
+        response = [[NSURLResponse alloc] initWithURL:self.baseURL MIMEType:nil expectedContentLength:0 textEncodingName:nil];
+    }
     NSString *descriptionFormat = @"The session data task failed. Original request was: %@";
     NSString *description = [NSString stringWithFormat:descriptionFormat, request];
     NSString *reason = @"Unexpected response";

--- a/MapboxMobileEvents/MMEAPIClient.m
+++ b/MapboxMobileEvents/MMEAPIClient.m
@@ -19,6 +19,8 @@ typedef NS_ENUM(NSInteger, MMEErrorCode) {
 
 @end
 
+NSString *const kMMEResponseKey = @"MMEResponseKey";
+
 @implementation MMEAPIClient
 
 - (instancetype)initWithAccessToken:(NSString *)accessToken userAgentBase:(NSString *)userAgentBase hostSDKVersion:(NSString *)hostSDKVersion {
@@ -125,9 +127,11 @@ typedef NS_ENUM(NSInteger, MMEErrorCode) {
         NSString *reasonFormat = @"The status code was %ld";
         NSString *description = [NSString stringWithFormat:descriptionFormat, request];
         NSString *reason = [NSString stringWithFormat:reasonFormat, (long)httpResponse.statusCode];
-        NSDictionary *userInfo = @{NSLocalizedDescriptionKey: description,
-                                   @"MMEHTTPResponseKey": httpResponse,
-                                   NSLocalizedFailureReasonErrorKey: reason};
+        NSDictionary *userInfo = [[NSMutableDictionary alloc] init];
+        [userInfo setValue:description forKey:NSLocalizedDescriptionKey];
+        [userInfo setValue:reason forKey:NSLocalizedFailureReasonErrorKey];
+        [userInfo setValue:httpResponse forKey:kMMEResponseKey];
+        
         statusError = [NSError errorWithDomain:MMEErrorDomain code:MMESessionFailedError userInfo:userInfo];
     }
     return statusError;
@@ -140,9 +144,11 @@ typedef NS_ENUM(NSInteger, MMEErrorCode) {
     NSString *descriptionFormat = @"The session data task failed. Original request was: %@";
     NSString *description = [NSString stringWithFormat:descriptionFormat, request];
     NSString *reason = @"Unexpected response";
-    NSDictionary *userInfo = @{NSLocalizedDescriptionKey: description,
-                               @"MMEResponseKey": response,
-                               NSLocalizedFailureReasonErrorKey: reason};
+    NSDictionary *userInfo = [[NSMutableDictionary alloc] init];
+    [userInfo setValue:description forKey:NSLocalizedDescriptionKey];
+    [userInfo setValue:reason forKey:NSLocalizedFailureReasonErrorKey];
+    [userInfo setValue:response forKey:kMMEResponseKey];
+    
     NSError *statusError = [NSError errorWithDomain:MMEErrorDomain code:MMEUnexpectedResponseError userInfo:userInfo];
     return statusError;
 }

--- a/MapboxMobileEvents/MMEAPIClient.m
+++ b/MapboxMobileEvents/MMEAPIClient.m
@@ -117,7 +117,7 @@ NSString *const kMMEResponseKey = @"MMEResponseKey";
 
 #pragma mark - Utilities
 
-- (NSError *)statusErrorFromRequest:(NSURLRequest *)request andHTTPResponse:(NSHTTPURLResponse *)httpResponse {
+- (NSError *)statusErrorFromRequest:(nonnull NSURLRequest *)request andHTTPResponse:(nonnull NSHTTPURLResponse *)httpResponse {
     if (!httpResponse) {
         httpResponse = [[NSHTTPURLResponse alloc] initWithURL:self.baseURL statusCode:0 HTTPVersion:nil headerFields:nil];
     }
@@ -125,7 +125,7 @@ NSString *const kMMEResponseKey = @"MMEResponseKey";
     if (httpResponse.statusCode >= 400) {
         NSString *descriptionFormat = @"The session data task failed. Original request was: %@";
         NSString *reasonFormat = @"The status code was %ld";
-        NSString *description = [NSString stringWithFormat:descriptionFormat, request];
+        NSString *description = [NSString stringWithFormat:descriptionFormat, request ?: [NSNull null]];
         NSString *reason = [NSString stringWithFormat:reasonFormat, (long)httpResponse.statusCode];
         NSDictionary *userInfo = [[NSMutableDictionary alloc] init];
         [userInfo setValue:description forKey:NSLocalizedDescriptionKey];
@@ -137,12 +137,12 @@ NSString *const kMMEResponseKey = @"MMEResponseKey";
     return statusError;
 }
 
-- (NSError *)unexpectedResponseErrorfromRequest:(NSURLRequest *)request andResponse:(NSURLResponse *)response {
+- (NSError *)unexpectedResponseErrorfromRequest:(nonnull NSURLRequest *)request andResponse:(NSURLResponse *)response {
     if (!response) {
         response = [[NSURLResponse alloc] initWithURL:self.baseURL MIMEType:nil expectedContentLength:0 textEncodingName:nil];
     }
     NSString *descriptionFormat = @"The session data task failed. Original request was: %@";
-    NSString *description = [NSString stringWithFormat:descriptionFormat, request];
+    NSString *description = [NSString stringWithFormat:descriptionFormat, request ?: [NSNull null]];
     NSString *reason = @"Unexpected response";
     NSDictionary *userInfo = [[NSMutableDictionary alloc] init];
     [userInfo setValue:description forKey:NSLocalizedDescriptionKey];

--- a/MapboxMobileEvents/MMEAPIClient.m
+++ b/MapboxMobileEvents/MMEAPIClient.m
@@ -118,16 +118,13 @@ NSString *const kMMEResponseKey = @"MMEResponseKey";
 #pragma mark - Utilities
 
 - (NSError *)statusErrorFromRequest:(nonnull NSURLRequest *)request andHTTPResponse:(nonnull NSHTTPURLResponse *)httpResponse {
-    if (!httpResponse) {
-        httpResponse = [[NSHTTPURLResponse alloc] initWithURL:self.baseURL statusCode:0 HTTPVersion:nil headerFields:nil];
-    }
     NSError *statusError = nil;
     if (httpResponse.statusCode >= 400) {
         NSString *descriptionFormat = @"The session data task failed. Original request was: %@";
         NSString *reasonFormat = @"The status code was %ld";
         NSString *description = [NSString stringWithFormat:descriptionFormat, request ?: [NSNull null]];
         NSString *reason = [NSString stringWithFormat:reasonFormat, (long)httpResponse.statusCode];
-        NSDictionary *userInfo = [[NSMutableDictionary alloc] init];
+        NSMutableDictionary *userInfo = [[NSMutableDictionary alloc] init];
         [userInfo setValue:description forKey:NSLocalizedDescriptionKey];
         [userInfo setValue:reason forKey:NSLocalizedFailureReasonErrorKey];
         [userInfo setValue:httpResponse forKey:kMMEResponseKey];
@@ -138,13 +135,10 @@ NSString *const kMMEResponseKey = @"MMEResponseKey";
 }
 
 - (NSError *)unexpectedResponseErrorfromRequest:(nonnull NSURLRequest *)request andResponse:(NSURLResponse *)response {
-    if (!response) {
-        response = [[NSURLResponse alloc] initWithURL:self.baseURL MIMEType:nil expectedContentLength:0 textEncodingName:nil];
-    }
     NSString *descriptionFormat = @"The session data task failed. Original request was: %@";
     NSString *description = [NSString stringWithFormat:descriptionFormat, request ?: [NSNull null]];
     NSString *reason = @"Unexpected response";
-    NSDictionary *userInfo = [[NSMutableDictionary alloc] init];
+    NSMutableDictionary *userInfo = [[NSMutableDictionary alloc] init];
     [userInfo setValue:description forKey:NSLocalizedDescriptionKey];
     [userInfo setValue:reason forKey:NSLocalizedFailureReasonErrorKey];
     [userInfo setValue:response forKey:kMMEResponseKey];

--- a/MapboxMobileEventsTests/MMEAPIClientTests.mm
+++ b/MapboxMobileEventsTests/MMEAPIClientTests.mm
@@ -143,8 +143,8 @@ describe(@"MMEAPIClient", ^{
                     NSURLRequest *requestFake = [[NSURLRequest alloc] initWithURL:apiClient.baseURL];
                     
                     [sessionWrapperFake completeProcessingWithData:nil response:responseFake error:error];
-                    [apiClient statusErrorFromRequest:requestFake andHTTPResponse:responseFake];
-                    [apiClient unexpectedResponseErrorfromRequest:requestFake andResponse:responseFake];
+                    [apiClient statusErrorFromRequest:requestFake andHTTPResponse:responseFake] should be_nil;
+                    [apiClient unexpectedResponseErrorfromRequest:requestFake andResponse:responseFake] should_not be_nil;
                 });
                 
                 it(@"should equal completed process error", ^{

--- a/MapboxMobileEventsTests/MMEAPIClientTests.mm
+++ b/MapboxMobileEventsTests/MMEAPIClientTests.mm
@@ -116,6 +116,44 @@ describe(@"MMEAPIClient", ^{
         });
     });
     
+    describe(@"- getConfigurationWithCompletionHandler:", ^{
+        __block MMENSURLSessionWrapperFake *sessionWrapperFake;
+        __block NSError *capturedError;
+        
+        beforeEach(^{
+            sessionWrapperFake = [[MMENSURLSessionWrapperFake alloc] init];
+            spy_on(sessionWrapperFake);
+            
+            apiClient.sessionWrapper = sessionWrapperFake;
+        });
+        
+        context(@"when getting configuration", ^{
+            __block NSError *error;
+            
+            beforeEach(^{
+                [apiClient getConfigurationWithCompletionHandler:^(NSError * _Nullable error, NSData * _Nullable data) {
+                    capturedError = error;
+                }];
+            });
+            
+            context(@"when network is offline", ^{
+                beforeEach(^{
+                    error = [NSError errorWithDomain:@"test" code:42 userInfo:nil];
+                    NSHTTPURLResponse *responseFake = nil;
+                    NSURLRequest *requestFake = [[NSURLRequest alloc] initWithURL:apiClient.baseURL];
+                    
+                    [sessionWrapperFake completeProcessingWithData:nil response:responseFake error:error];
+                    [apiClient statusErrorFromRequest:requestFake andHTTPResponse:responseFake];
+                    [apiClient unexpectedResponseErrorfromRequest:requestFake andResponse:responseFake];
+                });
+                
+                it(@"should equal completed process error", ^{
+                    capturedError should equal(error);
+                });
+            });
+        });
+    });
+    
     describe(@"- postEvent:completionHandler:", ^{
         __block MMEEvent *event;
         __block MMENSURLSessionWrapperFake *sessionWrapperFake;
@@ -155,20 +193,6 @@ describe(@"MMEAPIClient", ^{
                 beforeEach(^{
                     error = [NSError errorWithDomain:@"test" code:42 userInfo:nil];
                     NSHTTPURLResponse *responseFake = [[NSHTTPURLResponse alloc] initWithURL:apiClient.baseURL statusCode:400 HTTPVersion:nil headerFields:nil];
-                    [sessionWrapperFake completeProcessingWithData:nil response:responseFake error:error];
-                });
-                
-                it(@"should equal completed process error", ^{
-                    capturedError should equal(error);
-                });
-            });
-            
-            context(@"when network is offline", ^{
-                __block NSError *error;
-                
-                beforeEach(^{
-                    error = [NSError errorWithDomain:@"test" code:42 userInfo:nil];
-                    NSHTTPURLResponse *responseFake = nil;
                     [sessionWrapperFake completeProcessingWithData:nil response:responseFake error:error];
                 });
                 

--- a/MapboxMobileEventsTests/MMEAPIClientTests.mm
+++ b/MapboxMobileEventsTests/MMEAPIClientTests.mm
@@ -163,6 +163,20 @@ describe(@"MMEAPIClient", ^{
                 });
             });
             
+            context(@"when network is offline", ^{
+                __block NSError *error;
+                
+                beforeEach(^{
+                    error = [NSError errorWithDomain:@"test" code:42 userInfo:nil];
+                    NSHTTPURLResponse *responseFake = nil;
+                    [sessionWrapperFake completeProcessingWithData:nil response:responseFake error:error];
+                });
+                
+                it(@"should equal completed process error", ^{
+                    capturedError should equal(error);
+                });
+            });
+            
             context(@"when there is a response with an invalid status code", ^{
                 beforeEach(^{
                     NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"http:test.com"]


### PR DESCRIPTION
Crash that happens when there is no network connection and the response is `nil`. This PR changes error constructor methods to use `NSMutableDictionary` and `setValue:` to allow for `nil` values.

Fixes https://github.com/mapbox/mapbox-events-ios/issues/69