### PR TITLE
Fix namespacing for MMEHashProvider

### DIFF
--- a/MapboxMobileEvents.xcodeproj/project.pbxproj
+++ b/MapboxMobileEvents.xcodeproj/project.pbxproj
@@ -131,6 +131,10 @@
 		40FB437D1EFAFAE900EC5BC0 /* MMETimerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 40FB437B1EFAFAE900EC5BC0 /* MMETimerManager.m */; };
 		40FB437E1EFAFAE900EC5BC0 /* MMETimerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 40FB437B1EFAFAE900EC5BC0 /* MMETimerManager.m */; };
 		40FB43801EFAFDCF00EC5BC0 /* MMETimerManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 40FB437F1EFAFDCF00EC5BC0 /* MMETimerManagerTests.m */; };
+		96AB5106216416AE00A261B8 /* MMEHashProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = AC2C7167211376DA004179E0 /* MMEHashProvider.m */; };
+		96AB5108216416E800A261B8 /* MMETrustKitProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = ACC8C1CB210FAFF400C5055C /* MMETrustKitProvider.m */; };
+		96AB510A2164178900A261B8 /* MMEConfigurator.h in Headers */ = {isa = PBXBuildFile; fileRef = AC2C7162211241CC004179E0 /* MMEConfigurator.h */; };
+		96AB510B21641A6000A261B8 /* MMEUINavigation.m in Sources */ = {isa = PBXBuildFile; fileRef = ACE4F0191FD6102100035880 /* MMEUINavigation.m */; };
 		AC2C715E2112408A004179E0 /* MMEDispatchManager.h in Headers */ = {isa = PBXBuildFile; fileRef = AC2C715C21124089004179E0 /* MMEDispatchManager.h */; };
 		AC2C715F2112408A004179E0 /* MMEDispatchManager.m in Sources */ = {isa = PBXBuildFile; fileRef = AC2C715D2112408A004179E0 /* MMEDispatchManager.m */; };
 		AC2C716021124099004179E0 /* MMEDispatchManager.m in Sources */ = {isa = PBXBuildFile; fileRef = AC2C715D2112408A004179E0 /* MMEDispatchManager.m */; };
@@ -606,6 +610,7 @@
 				40AE585E1EA93B3A0046B437 /* MMECommonEventData.h in Headers */,
 				40FB437C1EFAFAE900EC5BC0 /* MMETimerManager.h in Headers */,
 				AC2C715E2112408A004179E0 /* MMEDispatchManager.h in Headers */,
+				96AB510A2164178900A261B8 /* MMEConfigurator.h in Headers */,
 				40C6118C1F18319000E30A6C /* TSKTrustKitConfig.h in Headers */,
 				AC611F271FCDED2F00ABBF6D /* MMEEventLogReportViewController.h in Headers */,
 				4036EFBE1ED37D56009C40BA /* MMEEventLogger.h in Headers */,
@@ -894,6 +899,7 @@
 				40C611621F18319000E30A6C /* parse_configuration.m in Sources */,
 				40C6118A1F18319000E30A6C /* TSKPinningValidatorResult.m in Sources */,
 				AC2C7165211241D0004179E0 /* MMEConfigurator.m in Sources */,
+				96AB510B21641A6000A261B8 /* MMEUINavigation.m in Sources */,
 				40F133551F200524007B4096 /* NSData+MMEGZIP.m in Sources */,
 				40FB437E1EFAFAE900EC5BC0 /* MMETimerManager.m in Sources */,
 				403835041F7AF150004205B9 /* MMEDependencyManager.m in Sources */,
@@ -905,10 +911,12 @@
 				40C611851F18319000E30A6C /* TSKPinningValidator.m in Sources */,
 				40C611651F18319000E30A6C /* ssl_pin_verifier.m in Sources */,
 				408596691ED086FA003BD29D /* MMENSURLSessionWrapper.m in Sources */,
+				96AB5108216416E800A261B8 /* MMETrustKitProvider.m in Sources */,
 				408596671ED086F4003BD29D /* MMECommonEventData.m in Sources */,
 				408596631ED086E8003BD29D /* CLLocation+MMEMobileEvents.m in Sources */,
 				40C611781F18319000E30A6C /* vendor_identifier.m in Sources */,
 				408596611ED086E2003BD29D /* MMEAPIClient.m in Sources */,
+				96AB5106216416AE00A261B8 /* MMEHashProvider.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MapboxMobileEvents/MMENamespacedDependencies.h
+++ b/MapboxMobileEvents/MMENamespacedDependencies.h
@@ -1,4 +1,5 @@
-// Namespaced Header
+// This namespaced header is generated.
+// Add source files to the MapboxMobileEventsStatic target, then run `make name-header`.
 
 #ifndef __NS_SYMBOL
 // We need to have multiple levels of macros here so that __NAMESPACE_PREFIX_ is

--- a/MapboxMobileEvents/MMENamespacedDependencies.h
+++ b/MapboxMobileEvents/MMENamespacedDependencies.h
@@ -58,6 +58,10 @@
 #define MMEEventsManager __NS_SYMBOL(MMEEventsManager)
 #endif
 
+#ifndef MMEHashProvider
+#define MMEHashProvider __NS_SYMBOL(MMEHashProvider)
+#endif
+
 #ifndef MMELocationManager
 #define MMELocationManager __NS_SYMBOL(MMELocationManager)
 #endif

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -24,7 +24,8 @@ function generate_namespace_header {
 
     echo "Generating $NAME_HEADER from $1"
 
-    echo "// Namespaced Header
+    echo "// This namespaced header is generated.
+// Add source files to the MapboxMobileEventsStatic target, then run \`make name-header\`.
 
 #ifndef __NS_SYMBOL
 // We need to have multiple levels of macros here so that __NAMESPACE_PREFIX_ is


### PR DESCRIPTION
Fixes #70 by adding `MMEHashProvider.m` to `MapboxMobileEventsStatic` and then regenerating the namespaced header.

There’s not currently a way in this project to test if the namespacing works, but it can be done somewhat trivially with the iOS maps SDK by running:

```
$ nm Mapbox.framework/Mapbox | grep \$_MME

0000000000426140 s _OBJC_CLASS_$_MMEHashProvider
0000000000423f60 s _OBJC_IVAR_$_MMEHashProvider._cnHashes
0000000000423f68 s _OBJC_IVAR_$_MMEHashProvider._comHashes
0000000000426168 s _OBJC_METACLASS_$_MMEHashProvider
```

No unprefixed/unnamespaced symbols should be found.

/cc @rclee @frederoni @julianrex 