### PR TITLE
Allow queuing of events while paused

### DIFF
--- a/MapboxMobileEvents/MMEEventsManager.m
+++ b/MapboxMobileEvents/MMEEventsManager.m
@@ -191,7 +191,6 @@
                                              MMEEventKeyLocalDebugDescription: @"Aborting flushing of event queue because collection is paused."}];
         
         if (self.eventQueue.count >= self.configuration.eventFlushCountThreshold) {
-            [self.eventQueue removeAllObjects];
             [self pushDebugEventWithAttributes:@{MMEDebugEventType: MMEDebugEventTypeFlush,
                                                  MMEEventKeyLocalDebugDescription: @"Emptying queue because threshold has passed and collection is paused"}];
         }

--- a/MapboxMobileEvents/MMEEventsManager.m
+++ b/MapboxMobileEvents/MMEEventsManager.m
@@ -189,11 +189,6 @@
     if (self.paused) {
         [self pushDebugEventWithAttributes:@{MMEDebugEventType: MMEDebugEventTypeFlush,
                                              MMEEventKeyLocalDebugDescription: @"Aborting flushing of event queue because collection is paused."}];
-        
-        if (self.eventQueue.count >= self.configuration.eventFlushCountThreshold) {
-            [self pushDebugEventWithAttributes:@{MMEDebugEventType: MMEDebugEventTypeFlush,
-                                                 MMEEventKeyLocalDebugDescription: @"Emptying queue because threshold has passed and collection is paused"}];
-        }
         return;
     }
     

--- a/MapboxMobileEvents/MMEEventsManager.m
+++ b/MapboxMobileEvents/MMEEventsManager.m
@@ -187,6 +187,8 @@
 
 - (void)flush {
     if (self.paused) {
+        [self pushDebugEventWithAttributes:@{MMEDebugEventType: MMEDebugEventTypeFlush,
+                                             MMEEventKeyLocalDebugDescription: @"Aborting flushing of event queue because collection is paused."}];
         return;
     }
     
@@ -444,12 +446,6 @@
         return;
     }
     
-    if (self.paused) {
-        [self pushDebugEventWithAttributes:@{MMEDebugEventType: MMEDebugEventTypePush,
-                                             MMEEventKeyLocalDebugDescription: @"Aborting pushing event because collection is paused."}];
-        return;
-    }
-    
     [self.eventQueue addObject:event];
     [self pushDebugEventWithAttributes:@{MMEDebugEventType: MMEDebugEventTypePush,
                                          MMEEventKeyLocalDebugDescription: [NSString stringWithFormat:@"Added event to event queue; event queue now has %ld events", (long)self.eventQueue.count]}];
@@ -491,6 +487,7 @@
     if (self.timerManager && configuration.eventFlushSecondsThreshold != self.timerManager.timeInterval) {
         [self.timerManager cancel];
         self.timerManager = [[MMETimerManager alloc] initWithTimeInterval:self.configuration.eventFlushSecondsThreshold target:self selector:@selector(flush)];
+        [self.timerManager start];
     }
 }
 

--- a/MapboxMobileEvents/MMEEventsManager.m
+++ b/MapboxMobileEvents/MMEEventsManager.m
@@ -189,6 +189,12 @@
     if (self.paused) {
         [self pushDebugEventWithAttributes:@{MMEDebugEventType: MMEDebugEventTypeFlush,
                                              MMEEventKeyLocalDebugDescription: @"Aborting flushing of event queue because collection is paused."}];
+        
+        if (self.eventQueue.count >= self.configuration.eventFlushCountThreshold) {
+            [self.eventQueue removeAllObjects];
+            [self pushDebugEventWithAttributes:@{MMEDebugEventType: MMEDebugEventTypeFlush,
+                                                 MMEEventKeyLocalDebugDescription: @"Emptying queue because threshold has passed and collection is paused"}];
+        }
         return;
     }
     

--- a/MapboxMobileEventsTests/MMEEventsManagerTests.mm
+++ b/MapboxMobileEventsTests/MMEEventsManagerTests.mm
@@ -902,8 +902,8 @@ describe(@"MMEEventsManager", ^{
                     [eventsManager enqueueEventWithName:MMEEventTypeMapLoad];
                 });
                 
-                it(@"has no event", ^{
-                    eventsManager.eventQueue.count should equal(0);
+                it(@"should queue events", ^{
+                    eventsManager.eventQueue.count should equal(1);
                 });
             });
         });


### PR DESCRIPTION
Addresses an issue where the first event wouldn't be queued during initialization of the events library.

Also adds timer start after configuration.

cc: @andrlee 