### PR TITLE
Rename offline event classes

### DIFF
--- a/MapboxMobileEvents/MMEConstants.h
+++ b/MapboxMobileEvents/MMEConstants.h
@@ -36,7 +36,7 @@ extern NSString * const MMEEventTypeLocation;
 extern NSString * const MMEEventTypeVisit;
 extern NSString * const MMEEventTypeLocalDebug;
 extern NSString * const MMEventTypeOfflineDownloadStart;
-extern NSString * const MMEventTypeOfflineDownloadComplete;
+extern NSString * const MMEventTypeOfflineDownloadEnd;
 
 // Gestures
 extern NSString * const MMEEventGestureSingleTap;

--- a/MapboxMobileEvents/MMEConstants.m
+++ b/MapboxMobileEvents/MMEConstants.m
@@ -34,7 +34,7 @@ NSString * const MMEEventTypeLocation = @"location";
 NSString * const MMEEventTypeVisit = @"visit";
 NSString * const MMEEventTypeLocalDebug = @"debug";
 NSString * const MMEventTypeOfflineDownloadStart = @"map.offlineDownload.start";
-NSString * const MMEventTypeOfflineDownloadComplete = @"map.offlineDownload.complete";
+NSString * const MMEventTypeOfflineDownloadEnd = @"map.offlineDownload.end";
 
 NSString * const MMEEventGestureSingleTap = @"SingleTap";
 NSString * const MMEEventGestureDoubleTap = @"DoubleTap";

--- a/MapboxMobileEvents/MMEEvent.h
+++ b/MapboxMobileEvents/MMEEvent.h
@@ -13,8 +13,8 @@
 + (instancetype)mapLoadEventWithDateString:(NSString *)dateString commonEventData:(MMECommonEventData *)commonEventData;
 + (instancetype)mapTapEventWithDateString:(NSString *)dateString attributes:(NSDictionary *)attributes;
 + (instancetype)mapDragEndEventWithDateString:(NSString *)dateString attributes:(NSDictionary *)attributes;
-+ (instancetype)mapOfflineDownloadStartWithDateString:(NSString *)dateString attributes:(NSDictionary *)attributes;
-+ (instancetype)mapOfflineDownloadCompleteWithDateString:(NSString *)dateString attributes:(NSDictionary *)attributes;
++ (instancetype)mapOfflineDownloadStartEventWithDateString:(NSString *)dateString attributes:(NSDictionary *)attributes;
++ (instancetype)mapOfflineDownloadEndEventWithDateString:(NSString *)dateString attributes:(NSDictionary *)attributes;
 + (instancetype)navigationEventWithName:(NSString *)name attributes:(NSDictionary *)attributes;
 + (instancetype)visionEventWithName:(NSString *)name attributes:(NSDictionary *)attributes;
 + (instancetype)debugEventWithAttributes:(NSDictionary *)attributes;

--- a/MapboxMobileEvents/MMEEvent.m
+++ b/MapboxMobileEvents/MMEEvent.m
@@ -83,7 +83,7 @@
     return mapTapEvent;
 }
 
-+ (instancetype)mapOfflineDownloadStartWithDateString:(NSString *)dateString attributes:(NSDictionary *)attributes {
++ (instancetype)mapOfflineDownloadStartEventWithDateString:(NSString *)dateString attributes:(NSDictionary *)attributes {
     MMEEvent *mapOfflineDownloadEvent = [[MMEEvent alloc] init];
     mapOfflineDownloadEvent.name = MMEventTypeOfflineDownloadStart;
     NSMutableDictionary *commonAttributes = [NSMutableDictionary dictionary];
@@ -94,9 +94,9 @@
     return mapOfflineDownloadEvent;
 }
 
-+ (instancetype)mapOfflineDownloadCompleteWithDateString:(NSString *)dateString attributes:(NSDictionary *)attributes {
++ (instancetype)mapOfflineDownloadEndEventWithDateString:(NSString *)dateString attributes:(NSDictionary *)attributes {
     MMEEvent *mapOfflineDownloadEvent = [[MMEEvent alloc] init];
-    mapOfflineDownloadEvent.name = MMEventTypeOfflineDownloadComplete;
+    mapOfflineDownloadEvent.name = MMEventTypeOfflineDownloadEnd;
     NSMutableDictionary *commonAttributes = [NSMutableDictionary dictionary];
     commonAttributes[MMEEventKeyEvent] = mapOfflineDownloadEvent.name;
     commonAttributes[MMEEventKeyCreated] = dateString;

--- a/MapboxMobileEvents/MMEEventsManager.m
+++ b/MapboxMobileEvents/MMEEventsManager.m
@@ -328,9 +328,9 @@
         event = [MMEEvent mapDragEndEventWithDateString:[self.dateWrapper formattedDateStringForDate:[self.dateWrapper date]]
                                              attributes:attributes];
     } else if ([name isEqualToString:MMEventTypeOfflineDownloadStart]) {
-        event = [MMEEvent mapOfflineDownloadStartWithDateString:[self.dateWrapper formattedDateStringForDate:[self.dateWrapper date]] attributes:attributes];
-    } else if ([name isEqualToString:MMEventTypeOfflineDownloadComplete]) {
-        event = [MMEEvent mapOfflineDownloadCompleteWithDateString:[self.dateWrapper formattedDateStringForDate:[self.dateWrapper date]] attributes:attributes];
+        event = [MMEEvent mapOfflineDownloadStartEventWithDateString:[self.dateWrapper formattedDateStringForDate:[self.dateWrapper date]] attributes:attributes];
+    } else if ([name isEqualToString:MMEventTypeOfflineDownloadEnd]) {
+        event = [MMEEvent mapOfflineDownloadEndEventWithDateString:[self.dateWrapper formattedDateStringForDate:[self.dateWrapper date]] attributes:attributes];
     }
     
     if ([name hasPrefix:MMENavigationEventPrefix]) {

--- a/MapboxMobileEvents/MMENamespacedDependencies.h
+++ b/MapboxMobileEvents/MMENamespacedDependencies.h
@@ -429,8 +429,8 @@
 #define MMEventTypeOfflineDownloadStart __NS_SYMBOL(MMEventTypeOfflineDownloadStart)
 #endif
 
-#ifndef MMEventTypeOfflineDownloadComplete
-#define MMEventTypeOfflineDownloadComplete __NS_SYMBOL(MMEventTypeOfflineDownloadComplete)
+#ifndef MMEventTypeOfflineDownloadEnd
+#define MMEventTypeOfflineDownloadEnd __NS_SYMBOL(MMEventTypeOfflineDownloadEnd)
 #endif
 
 #ifndef MMEEventGestureSingleTap

--- a/MapboxMobileEventsTests/MMEEventsManagerTests.mm
+++ b/MapboxMobileEventsTests/MMEEventsManagerTests.mm
@@ -780,20 +780,20 @@ describe(@"MMEEventsManager", ^{
                 });
                 
                 it(@"has the correct event", ^{
-                    MMEEvent *expectedEvent = [MMEEvent mapOfflineDownloadStartWithDateString:dateString attributes:attributes];
+                    MMEEvent *expectedEvent = [MMEEvent mapOfflineDownloadStartEventWithDateString:dateString attributes:attributes];
                     MMEEvent *event = eventsManager.eventQueue.firstObject;
                     
                     event should equal(expectedEvent);
                 });
             });
             
-            context(@"when a map download complete event is pushed", ^{
+            context(@"when a map download end event is pushed", ^{
                 beforeEach(^{
-                    [eventsManager enqueueEventWithName:MMEventTypeOfflineDownloadComplete attributes:attributes];
+                    [eventsManager enqueueEventWithName:MMEventTypeOfflineDownloadEnd attributes:attributes];
                 });
                 
                 it(@"has the correct event", ^{
-                    MMEEvent *expectedEvent = [MMEEvent mapOfflineDownloadCompleteWithDateString:dateString attributes:attributes];
+                    MMEEvent *expectedEvent = [MMEEvent mapOfflineDownloadEndEventWithDateString:dateString attributes:attributes];
                     MMEEvent *event = eventsManager.eventQueue.firstObject;
                     
                     event should equal(expectedEvent);


### PR DESCRIPTION
Edits the class names to more closely match other class names in this library, and renames the `mapOfflineDownloadCompleteWithDateString` to `mapOfflineDownloadEndEventWithDateString` so we can account for other states such as `success` / `cancelled` / `failed`.

*Before:*
```objc
+ (instancetype)mapOfflineDownloadStartWithDateString
+ (instancetype)mapOfflineDownloadCompleteWithDateString
```

*After:*

```objc
+ (instancetype)mapOfflineDownloadStartEventWithDateString
+ (instancetype)mapOfflineDownloadEndEventWithDateString
```