### PR TITLE
Provide whitelisted event initializer

### DIFF
--- a/MapboxMobileEvents.xcodeproj/xcshareddata/xcschemes/MapboxMobileMetrics.xcscheme
+++ b/MapboxMobileEvents.xcodeproj/xcshareddata/xcschemes/MapboxMobileMetrics.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1010"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MapboxMobileEvents/MMEEvent.h
+++ b/MapboxMobileEvents/MMEEvent.h
@@ -21,5 +21,6 @@
 + (instancetype)debugEventWithAttributes:(NSDictionary *)attributes;
 + (instancetype)searchEventWithName:(NSString *)name attributes:(NSDictionary *)attributes;
 + (instancetype)carplayEventWithName:(NSString *)name attributes:(NSDictionary *)attributes;
++ (instancetype)eventWithDateString:(NSString *)dateString name:(NSString *)name attributes:(NSDictionary *)attributes;
 
 @end

--- a/MapboxMobileEvents/MMEEvent.m
+++ b/MapboxMobileEvents/MMEEvent.m
@@ -160,6 +160,17 @@
     return carplayEvent;
 }
 
++ (instancetype)eventWithDateString:(NSString *)dateString name:(NSString *)name attributes:(NSDictionary *)attributes {
+    MMEEvent *event = [[MMEEvent alloc] init];
+    event.name = name;
+    NSMutableDictionary *commonAttributes = [NSMutableDictionary dictionary];
+    commonAttributes[MMEEventKeyEvent] = event.name;
+    commonAttributes[MMEEventKeyCreated] = dateString;
+    [commonAttributes addEntriesFromDictionary:attributes];
+    event.attributes = commonAttributes;
+    return event;
+}
+
 + (NSInteger)contentSizeScale {
     NSInteger result = -9999;
     

--- a/MapboxMobileEvents/MMEEventsManager.m
+++ b/MapboxMobileEvents/MMEEventsManager.m
@@ -388,8 +388,10 @@
                                              MMEEventKeyLocalDebugDescription: [NSString stringWithFormat:@"Pushing event: %@", event]}];
         [self pushEvent:event];
     } else {
+        event = [MMEEvent eventWithDateString:[self.dateWrapper formattedDateStringForDate:[self.dateWrapper date]] name:name attributes:attributes];
         [self pushDebugEventWithAttributes:@{MMEDebugEventType: MMEDebugEventTypePush,
-                                             MMEEventKeyLocalDebugDescription: [NSString stringWithFormat:@"Unknown event: %@", event]}];
+                                             MMEEventKeyLocalDebugDescription: [NSString stringWithFormat:@"Pushing generic event: %@", event]}];
+        [self pushEvent:event];
     }
 }
 

--- a/MapboxMobileEventsTests/MMEEventsManagerTests.mm
+++ b/MapboxMobileEventsTests/MMEEventsManagerTests.mm
@@ -896,13 +896,13 @@ describe(@"MMEEventsManager", ^{
                 });
             });
             
-            context(@"when an unknown event is pushed", ^{
+            context(@"when a generic event is pushed", ^{
                 beforeEach(^{
-                    [eventsManager enqueueEventWithName:@"invalid" attributes:attributes];
+                    [eventsManager enqueueEventWithName:@"generic" attributes:attributes];
                 });
                 
-                it(@"does not queue the event", ^{
-                    eventsManager.eventQueue.count should equal(0);
+                it(@"does queue the event", ^{
+                    eventsManager.eventQueue.count should equal(1);
                 });
             });
         });


### PR DESCRIPTION
This PR will add a generic event initializer to allow for faster iterations of new events. The main purpose of bringing this out now is our performance push and the need for many new events to be added and sent quickly.

Caution should be used when using this initializer. Such as enabling debug mode on `eventsManager` and ensuring your events make it to the server. Failure to do so could result in a loss of telemetry data.