### PR TITLE
Fix bug with telemetryMetrics and flush

### DIFF
--- a/MapboxMobileEvents/MMEEvent.m
+++ b/MapboxMobileEvents/MMEEvent.m
@@ -19,7 +19,7 @@
     commonAttributes[MMEEventKeyEvent] = telemetryMetrics.name;
     commonAttributes[MMEEventKeyCreated] = dateString;
     [commonAttributes addEntriesFromDictionary:attributes];
-    telemetryMetrics.attributes = attributes;
+    telemetryMetrics.attributes = commonAttributes;
     return telemetryMetrics;
 }
 

--- a/MapboxMobileEvents/MMEEventsManager.m
+++ b/MapboxMobileEvents/MMEEventsManager.m
@@ -209,6 +209,7 @@
     
     NSArray *events = [self.eventQueue copy];
     [self postEvents:events];
+    [self resetEventQueuing];
     
     [self pushDebugEventWithAttributes:@{MMEDebugEventType: MMEDebugEventTypeFlush,
                                          MMEEventKeyLocalDebugDescription:@"flush"}];

--- a/MapboxMobileEventsTests/MMEEventsManagerTests.mm
+++ b/MapboxMobileEventsTests/MMEEventsManagerTests.mm
@@ -496,7 +496,6 @@ describe(@"MMEEventsManager", ^{
                 beforeEach(^{
                     eventsManager.apiClient stub_method(@selector(accessToken)).and_return(nil);
                     [eventsManager flush];
-                    [eventsManager resetEventQueuing];
                 });
                 
                 it(@"does NOT tell the api client to post events", ^{
@@ -513,7 +512,6 @@ describe(@"MMEEventsManager", ^{
                     beforeEach(^{
                         eventsManager.eventQueue.count should equal(0);
                         [eventsManager flush];
-                        [eventsManager resetEventQueuing];
                     });
                     
                     it(@"does NOT tell the api client to post events", ^{
@@ -527,7 +525,6 @@ describe(@"MMEEventsManager", ^{
                         spy_on(eventsManager.timerManager);
                         [eventsManager enqueueEventWithName:MMEEventTypeMapLoad];
                         [eventsManager flush];
-                        [eventsManager resetEventQueuing];
                     });
                     
                     it(@"tells the api client to post events", ^{


### PR DESCRIPTION
`telemetryMetrics` events were not successfully reaching the server because of the one-liner on MMEEvent. 

Flush was causing some duplication of events when using the timer.