### PR TITLE
Fix for Issue 118

### DIFF
--- a/MapboxMobileEvents/MMEConstants.h
+++ b/MapboxMobileEvents/MMEConstants.h
@@ -88,6 +88,7 @@ extern NSString * const MMEEventKeyLocalDebugDescription;
 extern NSString * const MMEEventKeyErrorCode;
 extern NSString * const MMEEventKeyErrorDescription;
 extern NSString * const MMEEventKeyErrorFailureReason;
+extern NSString * const MMEEventKeyErrorNoReason;
 extern NSString * const MMEEventKeyFailedRequests;
 extern NSString * const MMEEventKeyHeader;
 extern NSString * const MMEEventKeyPlatform;

--- a/MapboxMobileEvents/MMEConstants.m
+++ b/MapboxMobileEvents/MMEConstants.m
@@ -66,6 +66,7 @@ NSString * const MMEEventKeyLocalDebugDescription = @"debug.description";
 NSString * const MMEEventKeyErrorCode = @"error.code";
 NSString * const MMEEventKeyErrorDescription = @"error.description";
 NSString * const MMEEventKeyErrorFailureReason = @"error.failureReason";
+NSString * const MMEEventKeyErrorNoReason = @"No Reason";
 NSString * const MMEEventKeyEvent = @"event";
 NSString * const MMEEventKeyCreated = @"created";
 NSString * const MMEEventKeyVendorID = @"userId";

--- a/MapboxMobileEvents/MMEEvent.m
+++ b/MapboxMobileEvents/MMEEvent.m
@@ -169,7 +169,7 @@
 
 + (instancetype)debugEventWithException:(NSException*) except {
     NSMutableDictionary* exceptionAttributes = [NSMutableDictionary dictionaryWithObject:MMEDebugEventTypeError forKey:MMEDebugEventType];
-    exceptionAttributes[MMEEventKeyErrorDescription] = (except.name ? except.name : except.description);
+    exceptionAttributes[MMEEventKeyErrorDescription] = except.name;
     exceptionAttributes[MMEEventKeyErrorFailureReason] = (except.reason ? except.reason : MMEEventKeyErrorNoReason);
     return [self debugEventWithAttributes:exceptionAttributes];
 }

--- a/MapboxMobileEvents/MMEEvent.m
+++ b/MapboxMobileEvents/MMEEvent.m
@@ -160,21 +160,18 @@
 }
 
 + (instancetype)debugEventWithError:(NSError*) error {
-    return [self debugEventWithAttributes:@{
-        MMEDebugEventType: MMEDebugEventTypeError,
-        MMEEventKeyErrorCode: @(error.code),
-        MMEEventKeyErrorDescription: error.localizedDescription,
-        MMEEventKeyErrorFailureReason: error.localizedFailureReason
-    }];
+    NSMutableDictionary* errorAttributes = [NSMutableDictionary dictionaryWithObject:MMEDebugEventTypeError forKey:MMEDebugEventType];
+    errorAttributes[MMEEventKeyErrorCode] = @(error.code);
+    errorAttributes[MMEEventKeyErrorDescription] = (error.localizedDescription ? error.localizedDescription : error.description);
+    errorAttributes[MMEEventKeyErrorFailureReason] = (error.localizedFailureReason ? error.localizedFailureReason : MMEEventKeyErrorNoReason);
+    return [self debugEventWithAttributes:errorAttributes];
 }
 
 + (instancetype)debugEventWithException:(NSException*) except {
-    return [self debugEventWithAttributes:@{
-        MMEDebugEventType: MMEDebugEventTypeError,
-        MMEEventKeyErrorDescription: except.name,
-        MMEEventKeyErrorFailureReason: except.reason
-        // TODO add the stack trace via .callstackSymbols after sanatizing the list
-    }];
+    NSMutableDictionary* exceptionAttributes = [NSMutableDictionary dictionaryWithObject:MMEDebugEventTypeError forKey:MMEDebugEventType];
+    exceptionAttributes[MMEEventKeyErrorDescription] = (except.name ? except.name : except.description);
+    exceptionAttributes[MMEEventKeyErrorFailureReason] = (except.reason ? except.reason : MMEEventKeyErrorNoReason);
+    return [self debugEventWithAttributes:exceptionAttributes];
 }
 
 + (instancetype)searchEventWithName:(NSString *)name attributes:(NSDictionary *)attributes {

--- a/MapboxMobileEventsTests/MMEEventTests.mm
+++ b/MapboxMobileEventsTests/MMEEventTests.mm
@@ -103,7 +103,7 @@ describe(@"MMEEvent", ^{
             errorEventWithAllInfo should_not be_nil;
         });
 
-        it(@"should create an MMEevent from a nil error", ^{
+        it(@"should create an MMEEevent from a nil error", ^{
             MMEEvent *errorEventWithNilError = [MMEEvent debugEventWithError:nil];
 
             errorEventWithNilError should_not be_nil;

--- a/MapboxMobileEventsTests/MMEEventTests.mm
+++ b/MapboxMobileEventsTests/MMEEventTests.mm
@@ -28,12 +28,12 @@ describe(@"MMEEvent", ^{
             event.name should equal(testName);
         });
 
-        it(@"should hace the test event attrs", ^{
+        it(@"should have the test event attrs", ^{
             event.attributes should equal(testAttrs);
         });
     });
 
-    context(@"- NSSecureCoding of MMEEvent", ^{
+    context(@"NSSecureCoding of MMEEvent", ^{
         MMEEvent *event = [MMEEvent eventWithName:testName attributes:testAttrs];
         NSString *tempFile = [NSTemporaryDirectory() stringByAppendingPathComponent:@"MMEEvent-test.data"];
         if ([NSFileManager.defaultManager fileExistsAtPath:tempFile]) {
@@ -74,6 +74,59 @@ describe(@"MMEEvent", ^{
                 unarchived should_not be_nil;
                 unarchived should equal(event);
             });
+        });
+    });
+
+    context(@"debugEventWithError", ^{
+        NSError *errorWithNoInfo = [NSError errorWithDomain:NSCocoaErrorDomain code:0 userInfo:nil];
+        NSError *errorWithAllInfo = [NSError errorWithDomain:NSCocoaErrorDomain code:1 userInfo:@{
+            NSURLErrorKey: [NSURL URLWithString:@"http://mapbox.com"],
+            NSHelpAnchorErrorKey: @"NSHelpAnchorErrorKey",
+            NSLocalizedDescriptionKey: @"NSLocalizedDescriptionKey",
+            NSLocalizedFailureReasonErrorKey: @"NSLocalizedFailureReasonErrorKey",
+            NSLocalizedRecoveryOptionsErrorKey: @[@"Abort", @"Retry", @"Fail"],
+            NSLocalizedRecoverySuggestionErrorKey: @"NSLocalizedRecoverySuggestionErrorKey",
+            NSStringEncodingErrorKey: @(NSUTF8StringEncoding),
+            NSUnderlyingErrorKey: errorWithNoInfo,
+            NSDebugDescriptionErrorKey: @"PC LOAD LETTER"
+        }];
+
+        it(@"should create an MMEEvent from errorWithNoInfo", ^{
+            MMEEvent *errorEventWithNoInfo = [MMEEvent debugEventWithError:errorWithNoInfo];
+
+            errorEventWithNoInfo should_not be_nil;
+        });
+
+        it(@"should crteate an MMEEvent from errorWithAllInfo", ^{
+            MMEEvent *errorEventWithAllInfo = [MMEEvent debugEventWithError:errorWithAllInfo];
+
+            errorEventWithAllInfo should_not be_nil;
+        });
+
+        it(@"should create an MMEevent from a nil error", ^{
+            MMEEvent *errorEventWithNilError = [MMEEvent debugEventWithError:nil];
+
+            errorEventWithNilError should_not be_nil;
+        });
+
+    });
+
+    context(@"debugEventWithException", ^{
+        NSException *exceptionWithNoInfo = [NSException exceptionWithName:NSGenericException reason:nil userInfo:nil];
+        NSException *exceptionWithAllInfo = [NSException exceptionWithName:NSGenericException reason:@"TestReason" userInfo:@{
+            @"ExceptionUserInfo": @"ExceptionUserInfo"
+        }];
+
+        it(@"should create an MMEEvent from exceptionWithNoInfo", ^{
+            MMEEvent *exceptionEventWithNoInfo = [MMEEvent debugEventWithException:exceptionWithNoInfo];
+
+            exceptionEventWithNoInfo should_not be_nil;
+        });
+
+        it(@"should create an MMEEvent from exceptionWithAllInfo", ^{
+            MMEEvent *exceptionEventWithAllInfo = [MMEEvent debugEventWithException:exceptionWithAllInfo];
+
+            exceptionEventWithAllInfo should_not be_nil;
         });
     });
 });


### PR DESCRIPTION
https://github.com/mapbox/mapbox-events-ios/issues/118

- Don't raise exceptions when Errors and Exceptions have nil fields
- Add test cases to cover populated and unpopulated Error and Exception event creation
- Review Music: ["Ain't No Reason"](https://www.youtube.com/watch?v=amwVyRH2B8A)