### PR TITLE
Disable TrustKit logging

### DIFF
--- a/vendor/TrustKit/TrustKit.m
+++ b/vendor/TrustKit/TrustKit.m
@@ -40,7 +40,7 @@ static TSKSPKIHashCache *sharedHashCache;
 
 // Default logger block: only log in debug builds and add TrustKit at the beginning of the line
 #if DEBUG
-void (^_loggerBlock)(NSString *) = ^void(NSString *message) { NSLog(@"=== TrustKit: %@", message); };
+void (^_loggerBlock)(NSString *) = NULL;
 #else
 void (^_loggerBlock)(NSString *) = NULL;
 #endif


### PR DESCRIPTION
TrustKit logging is causing too much debug logging in the console. Disabling this for now, since we'll soon be removing most of the TrustKit.