### PR TITLE
Debug cert logging

### DIFF
--- a/MapboxMobileEvents/MMEConstants.h
+++ b/MapboxMobileEvents/MMEConstants.h
@@ -29,6 +29,7 @@ extern NSString * const MMEDebugEventTypeBackgroundTask;
 extern NSString * const MMEDebugEventTypeMetricCollection;
 extern NSString * const MMEDebugEventTypeLocationManager;
 extern NSString * const MMEDebugEventTypeTelemetryMetrics;
+extern NSString * const MMEDebugEventTypeCertPinning;
 
 // Event types
 extern NSString * const MMEEventTypeAppUserTurnstile;

--- a/MapboxMobileEvents/MMEConstants.m
+++ b/MapboxMobileEvents/MMEConstants.m
@@ -29,6 +29,7 @@ NSString * const MMEDebugEventTypeBackgroundTask = @"backgroundTask";
 NSString * const MMEDebugEventTypeMetricCollection = @"metricCollection";
 NSString * const MMEDebugEventTypeLocationManager = @"locationManager";
 NSString * const MMEDebugEventTypeTelemetryMetrics = @"telemMetrics";
+NSString * const MMEDebugEventTypeCertPinning = @"certPinning";
 
 NSString * const MMEEventTypeAppUserTurnstile = @"appUserTurnstile";
 NSString * const MMEEventTypeTelemetryMetrics = @"telemetryMetrics";

--- a/MapboxMobileEvents/MMEEventLogger.h
+++ b/MapboxMobileEvents/MMEEventLogger.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+#import "MMETypes.h"
 
 @class MMEEvent;
 
@@ -13,6 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)logEvent:(MMEEvent *)event;
 - (void)readAndDisplayLogFileFromDate:(NSDate *)logDate;
+- (void)pushDebugEventWithAttributes:(MMEMapboxEventAttributes *)attributes;
 
 @end
 

--- a/MapboxMobileEvents/MMEEventLogger.m
+++ b/MapboxMobileEvents/MMEEventLogger.m
@@ -60,6 +60,13 @@
 
 #pragma mark - Write to Local File
 
+- (void)pushDebugEventWithAttributes:(MMEMapboxEventAttributes *)attributes {
+    MMEMutableMapboxEventAttributes *combinedAttributes = [MMEMutableMapboxEventAttributes dictionaryWithDictionary:attributes];
+    [combinedAttributes setObject:[MMEDate.iso8601DateFormatter stringFromDate:[NSDate date]] forKey:@"created"];
+    MMEEvent *debugEvent = [MMEEvent debugEventWithAttributes:combinedAttributes];
+    [MMEEventLogger.sharedLogger logEvent:debugEvent];
+}
+
 - (BOOL)timeForNewLogFile {
     return [[NSDate date] timeIntervalSinceDate:self.nextLogFileDate] > 0;
 }

--- a/MapboxMobileEvents/MMEMetricsManager.m
+++ b/MapboxMobileEvents/MMEMetricsManager.m
@@ -277,7 +277,7 @@
         NSString *debugDescription = [NSString stringWithFormat:@"TelemetryMetrics event isn't ready to be sent; writing to %@ and waiting until %@ to send",
             MMEMetricsManager.pendingMetricsEventPath, zeroHour];
         
-        [self pushDebugEventWithAttributes:@{
+        [MMEEventLogger.sharedLogger pushDebugEventWithAttributes:@{
             MMEDebugEventType: MMEDebugEventTypeTelemetryMetrics,
             MMEEventKeyLocalDebugDescription: debugDescription}];
 
@@ -293,7 +293,7 @@
                     if (![archiver.encodedData writeToFile:MMEMetricsManager.pendingMetricsEventPath atomically:YES]) {
                         debugDescription = [NSString stringWithFormat:@"Failed to archiveRootObject: %@ toFile: %@",
                             telemetryMetrics, MMEMetricsManager.pendingMetricsEventPath];
-                        [self pushDebugEventWithAttributes:@{
+                        [MMEEventLogger.sharedLogger pushDebugEventWithAttributes:@{
                             MMEDebugEventType: MMEDebugEventTypeTelemetryMetrics,
                             MMEEventKeyLocalDebugDescription: debugDescription}];
                     }
@@ -311,13 +311,6 @@
     [MMEMetricsManager deletePendingMetricsEventFile];
     
     return telemetryMetrics;
-}
-
-- (void)pushDebugEventWithAttributes:(NSDictionary *)attributes {
-    NSMutableDictionary *combinedAttributes = [NSMutableDictionary dictionaryWithDictionary:attributes];
-    [combinedAttributes setObject:[MMEDate.iso8601DateFormatter stringFromDate:NSDate.date] forKey:@"created"];
-    MMEEvent *debugEvent = [MMEEvent debugEventWithAttributes:attributes];
-    [MMEEventLogger.sharedLogger logEvent:debugEvent];
 }
 
 #pragma mark -

--- a/MapboxMobileEventsTests/MMECertPinTests.mm
+++ b/MapboxMobileEventsTests/MMECertPinTests.mm
@@ -82,7 +82,7 @@ describe(@"MMECertPin", ^{
 
         certificate should_not be_nil;
 
-        // for get publicKeyData to work we need to put MMETestCARoot into the kehchain
+        // for get publicKeyData to work we need to put MMETestCARoot into the keychain
         NSDictionary *addQuery = @{
             (id)kSecValueRef: (__bridge id)certificate,
             (id)kSecClass: (id)kSecClassCertificate,


### PR DESCRIPTION
- adds debug logs to `MMECertPin`
- replaces some comments with debug events/logs
- couple of small typos (one with `lastAuthChallengeDisposition`)

This will allow cert pinning logs to be printed to the console. Debug logging may help to give us insight into why a specific test is failing more quickly and serves as documentation.