### PR TITLE
Fix account leak

### DIFF
--- a/MapboxMobileEvents/MMEEventsManager.m
+++ b/MapboxMobileEvents/MMEEventsManager.m
@@ -74,6 +74,11 @@
 }
 
 - (void)initializeWithAccessToken:(NSString *)accessToken userAgentBase:(NSString *)userAgentBase hostSDKVersion:(NSString *)hostSDKVersion {
+    if (self.apiClient) {
+        [self setAccessToken:accessToken];
+        return;
+    }
+    
     self.apiClient = [[MMEAPIClient alloc] initWithAccessToken:accessToken
         userAgentBase:userAgentBase
         hostSDKVersion:hostSDKVersion];

--- a/MapboxMobileEvents/MMENSURLSessionWrapper.m
+++ b/MapboxMobileEvents/MMENSURLSessionWrapper.m
@@ -65,7 +65,7 @@
 }
 
 -(void)URLSession:(NSURLSession *)session didBecomeInvalidWithError:(NSError *)error {
-    session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration] delegate:self delegateQueue:nil];
+    self.session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration] delegate:self delegateQueue:nil];
     if (error) {
         [[MMEEventsManager sharedManager] pushEvent:[MMEEvent debugEventWithError:error]];
     }

--- a/MapboxMobileEvents/MMENSURLSessionWrapper.m
+++ b/MapboxMobileEvents/MMENSURLSessionWrapper.m
@@ -4,7 +4,6 @@
 
 @interface MMENSURLSessionWrapper ()
 
-@property (nonatomic) NSURLSession *session;
 @property (nonatomic) dispatch_queue_t serialQueue;
 @property (nonatomic) MMECertPin *certPin;
 
@@ -15,7 +14,6 @@
 - (instancetype)init {
     self = [super init];
     if (self) {
-        _session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration] delegate:self delegateQueue:nil];
         _serialQueue = dispatch_queue_create([[NSString stringWithFormat:@"%@.events.serial", NSStringFromClass([self class])] UTF8String], DISPATCH_QUEUE_SERIAL);
         _certPin = [[MMECertPin alloc]init];
     }
@@ -29,8 +27,10 @@
 #pragma mark MMENSURLSessionWrapper
 
 - (void)processRequest:(NSURLRequest *)request completionHandler:(void (^)(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error))completionHandler {
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration] delegate:nil delegateQueue:nil];
+    
     dispatch_async(self.serialQueue, ^{
-        __block NSURLSessionDataTask *dataTask = [self.session dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+        __block NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
             if (completionHandler) {
                 dispatch_async(dispatch_get_main_queue(), ^{
                     completionHandler(data, response, error);
@@ -39,6 +39,7 @@
             dataTask = nil;
         }];
         [dataTask resume];
+        [session finishTasksAndInvalidate];
     });
 }
 

--- a/MapboxMobileEventsTests/MMEEventsManagerTests.mm
+++ b/MapboxMobileEventsTests/MMEEventsManagerTests.mm
@@ -307,6 +307,25 @@ describe(@"MMEEventsManager", ^{
                         locations = @[location()];
                     });
                     
+                    context(@"when the events manager is re-initialized", ^{
+                        __block NSString *capturedAccessToken;
+                        __block MMEEventsManager *capturedEventsManager;
+                        
+                        beforeEach(^{
+                            capturedEventsManager = eventsManager;
+                            capturedAccessToken = eventsManager.accessToken;
+                            [eventsManager initializeWithAccessToken:@"access-token-reinit" userAgentBase:@"user-agent-base" hostSDKVersion:@"host-sdk-version"];
+                        });
+                        
+                        it(@"should not be re-initalized", ^{
+                            eventsManager should equal(capturedEventsManager);
+                        });
+                        
+                        it(@"should change the access token", ^{
+                            eventsManager.accessToken should_not equal(capturedAccessToken);
+                        });
+                    });
+                    
                     context(@"when the event count threshold has not yet been reached and a location event is received", ^{
                         beforeEach(^{
                             spy_on(eventsManager.timerManager);


### PR DESCRIPTION
This should fix a memory leak we have associated with MGLAccountManager. Two things needed to be fixed 

1) calling `initializeWithAccessToken: userAgentBase: hostSDKVersion:` too many times could cause memory leaks and potentially other issues.  
2) `MMENSURLSessionWrapper` wasn't being invalidated properly and was causing some memory leaks

ref: https://github.com/mapbox/gl-internal/issues/1126