### PR TITLE
Fix minor warnings

### DIFF
--- a/MapboxMobileEvents/MMEAPIClient.h
+++ b/MapboxMobileEvents/MMEAPIClient.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)getConfigurationWithCompletionHandler:(nullable void (^)(NSError * _Nullable error, NSData * _Nullable data))completionHandler;
 - (void)reconfigure:(MMEEventsConfiguration *)configuration;
-- (NSError *)statusErrorFromRequest:(NSURLRequest *)request andHTTPResponse:(NSHTTPURLResponse *)httpResponse;
+- (nullable NSError *)statusErrorFromRequest:(NSURLRequest *)request andHTTPResponse:(NSHTTPURLResponse *)httpResponse;
 - (NSError *)unexpectedResponseErrorfromRequest:(NSURLRequest *)request andResponse:(NSURLResponse *)response;
 
 @end

--- a/MapboxMobileEvents/MMEAPIClient.m
+++ b/MapboxMobileEvents/MMEAPIClient.m
@@ -165,7 +165,7 @@ int const kMMEMaxRequestCount = 1000;
 
 #pragma mark - Utilities
 
-- (NSError *)statusErrorFromRequest:(nonnull NSURLRequest *)request andHTTPResponse:(nonnull NSHTTPURLResponse *)httpResponse {
+- (NSError *)statusErrorFromRequest:(NSURLRequest *)request andHTTPResponse:(NSHTTPURLResponse *)httpResponse {
     NSError *statusError = nil;
     if (httpResponse.statusCode >= 400) {
         NSString *descriptionFormat = @"The session data task failed. Original request was: %@";

--- a/MapboxMobileEvents/MMEEventsConfiguration.m
+++ b/MapboxMobileEvents/MMEEventsConfiguration.m
@@ -8,8 +8,8 @@ static NSString *const kMMECustomProfile = @"Custom";
 
 static const CLLocationDistance kHibernationRadiusDefault = 300.0;
 static const CLLocationDistance kHibernationRadiusWide = 1200.0;
-static const NSUInteger kEventFlushCountThresholdDefault = 180;
-static const NSUInteger kEventFlushSecondsThresholdDefault = 180;
+static const NSUInteger kEventFlushCountThresholdDefault = 10;
+static const NSUInteger kEventFlushSecondsThresholdDefault = 10;
 static const NSTimeInterval kInitDelayTimeInterval = 10;
 static const NSTimeInterval kInstanceIdentifierRotationTimeIntervalDefault = 24 * 3600;
 static const NSTimeInterval kConfigurationRotationTimeIntervalDefault = 24 * 3600; // 24 hours

--- a/MapboxMobileEvents/Reachability/MMEReachability.m
+++ b/MapboxMobileEvents/Reachability/MMEReachability.m
@@ -99,6 +99,8 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
     if (ref)
     {
         id reachability = [[self alloc] initWithReachabilityRef:ref];
+        
+        CFRelease(ref);
 
         return reachability;
     }
@@ -112,6 +114,8 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
     if (ref)
     {
         id reachability = [[self alloc] initWithReachabilityRef:ref];
+        
+        CFRelease(ref);
 
         return reachability;
     }
@@ -149,13 +153,13 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
     self = [super init];
     if (self != nil)
     {
-        self.reachableOnWWAN = YES;
-        self.reachabilityRef = ref;
+        _reachableOnWWAN = YES;
+        _reachabilityRef = CFRetain(ref);
 
         // We need to create a serial queue.
         // We allocate this once for the lifetime of the notifier.
 
-        self.reachabilitySerialQueue = dispatch_queue_create("com.mapboxmobileevents.reachability", NULL);
+        _reachabilitySerialQueue = dispatch_queue_create("com.mapboxmobileevents.reachability", NULL);
     }
 
     return self;
@@ -165,15 +169,15 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
 {
     [self stopNotifier];
 
-    if(self.reachabilityRef)
+    if(_reachabilityRef)
     {
-        CFRelease(self.reachabilityRef);
-        self.reachabilityRef = nil;
+        CFRelease(_reachabilityRef);
+        _reachabilityRef = nil;
     }
 
-    self.reachableBlock          = nil;
-    self.unreachableBlock        = nil;
-    self.reachabilitySerialQueue = nil;
+    _reachableBlock          = nil;
+    _unreachableBlock        = nil;
+    _reachabilitySerialQueue = nil;
 }
 
 #pragma mark - Notifier Methods


### PR DESCRIPTION
This should fix some warnings we were seeing when running `analyze` on Xcode. Excluding the `nullable` fix since we have that already in an upcoming PR.

ref: https://github.com/mapbox/mapbox-events-ios/issues/128