### PR TITLE
Allow subclassing MMEEventsManager

### DIFF
--- a/MapboxMobileEvents/MMEEventsManager.m
+++ b/MapboxMobileEvents/MMEEventsManager.m
@@ -53,14 +53,10 @@
     
     dispatch_once(&onceToken, ^{
         [MMECategoryLoader loadCategories];
-        _sharedManager = [MMEEventsManager.alloc initShared];
+        _sharedManager = [[self alloc] initShared];
     });
     
     return _sharedManager;
-}
-
-- (instancetype)init {
-    return self.class.sharedManager;
 }
 
 - (instancetype)initShared {

--- a/MapboxMobileEventsTests/MMEEventsManagerTests.mm
+++ b/MapboxMobileEventsTests/MMEEventsManagerTests.mm
@@ -73,17 +73,6 @@ static CLLocation * location() {
 
 SPEC_BEGIN(MMEEventsManagerSpec)
 
-/* many of the tests use a manager which is not the shared manager,
-   in normal operation clietns should not use the private initShared method used for testsing */
-describe(@"MMEventsManager.sharedManager", ^{
-    MMEEventsManager *shared = MMEEventsManager.sharedManager;
-    MMEEventsManager *allocated = [MMEEventsManager.alloc init];
-
-    it(@"", ^{
-        shared should equal(allocated);
-    });
-});
-
 describe(@"MMEEventsManager", ^{
     
     __block MMEEventsManager *eventsManager;


### PR DESCRIPTION
We subclass MMEEventsManager in [mapbox-navigation-ios](https://github.com/mapbox/mapbox-navigation-ios)’s test suite and use dependency injection to validate telemetry collection.

Our tests started failing on https://github.com/mapbox/mapbox-navigation-ios/pull/2151 when we bumped the events library to v0.9.4. This was caused by a newly introduced singleton return value in MMEEventsManager initializer, which seems to be a guard against subclassing or just to ensure that the singleton is the only instance of MMEEventsManager.

Let me know if you have a better idea of how we could create a mock instance of MMEEventsManager to avoid these changes.

cc @1ec5 @rclee @alfwatt 