### PR TITLE
Create example subclass tests to clarify when to use `initShared`

### DIFF
--- a/MapboxMobileEventsTests/MMEEventsManagerTests.mm
+++ b/MapboxMobileEventsTests/MMEEventsManagerTests.mm
@@ -44,6 +44,18 @@ using namespace Cedar::Doubles::Arguments;
 
 #pragma mark -
 
+@interface MMEeventsManagerSubclass : MMEEventsManager
+
+@end
+
+#pragma mark -
+
+@implementation MMEeventsManagerSubclass
+
+@end
+
+#pragma mark -
+
 @interface MMEEvent (Tests)
 @property(nonatomic,retain) MMEDate *dateStorage;
 @property(nonatomic,retain) NSDictionary *attributesStorage;
@@ -71,16 +83,29 @@ static CLLocation * location() {
 
 #pragma mark -
 
+
 SPEC_BEGIN(MMEEventsManagerSpec)
 
-/* many of the tests use a manager which is not the shared manager,
-   in normal operation clietns should not use the private initShared method used for testsing */
+/* many of the tests use a manager which is not the sharedManager,
+   in normal operation clients should not use the private initShared method
+   tests which want a standalone instance should use `[MMEEventsManager.alloc sharedInit]` */
 describe(@"MMEventsManager.sharedManager", ^{
-    MMEEventsManager *shared = MMEEventsManager.sharedManager;
     MMEEventsManager *allocated = [MMEEventsManager.alloc init];
 
-    it(@"", ^{
-        shared should equal(allocated);
+    it(@"should be the sharedManager", ^{
+        allocated should equal(MMEEventsManager.sharedManager);
+    });
+});
+
+#pragma mark -
+
+/* this test shows how to create a custom subclass of MMEventsManager and get
+    a standalong instace of it by using the private `initShared` initilizer */
+describe(@"MMEventsManager subclass for testing", ^{
+    MMEeventsManagerSubclass *subclass = [MMEeventsManagerSubclass.alloc initShared];
+
+    it (@"should not be the sharedManager", ^{
+        subclass should_not equal(MMEEventsManager.sharedManager);
     });
 });
 

--- a/MapboxMobileEventsTests/MMEEventsManagerTests.mm
+++ b/MapboxMobileEventsTests/MMEEventsManagerTests.mm
@@ -1,5 +1,6 @@
 #import <Cedar/Cedar.h>
-#import "MMEEventsManager.h"
+#import <MapboxMobileEvents/MapboxMobileEvents.h>
+
 #import "MMEConstants.h"
 #import "MMEUniqueIdentifier.h"
 #import "MMEEventsConfiguration.h"
@@ -44,7 +45,7 @@ using namespace Cedar::Doubles::Arguments;
 
 #pragma mark -
 
-@interface MMEeventsManagerSubclass : MMEEventsManager
+@interface MMEEventsManagerSubclass : MMEEventsManager
 
 @end
 

--- a/MapboxMobileEventsTests/MMEEventsManagerTests.mm
+++ b/MapboxMobileEventsTests/MMEEventsManagerTests.mm
@@ -50,7 +50,7 @@ using namespace Cedar::Doubles::Arguments;
 
 #pragma mark -
 
-@implementation MMEeventsManagerSubclass
+@implementation MMEEventsManagerSubclass
 
 @end
 
@@ -100,9 +100,9 @@ describe(@"MMEventsManager.sharedManager", ^{
 #pragma mark -
 
 /* this test shows how to create a custom subclass of MMEventsManager and get
-    a standalong instace of it by using the private `initShared` initilizer */
+    a standalone instace of it by using the private `initShared` initilizer */
 describe(@"MMEventsManager subclass for testing", ^{
-    MMEeventsManagerSubclass *subclass = [MMEeventsManagerSubclass.alloc initShared];
+    MMEEventsManagerSubclass *subclass = [MMEEventsManagerSubclass.alloc initShared];
 
     it (@"should not be the sharedManager", ^{
         subclass should_not equal(MMEEventsManager.sharedManager);

--- a/MapboxMobileEventsTests/MMEEventsManagerTests.mm
+++ b/MapboxMobileEventsTests/MMEEventsManagerTests.mm
@@ -90,7 +90,7 @@ SPEC_BEGIN(MMEEventsManagerSpec)
 /* many of the tests use a manager which is not the sharedManager,
    in normal operation clients should not use the private initShared method
    tests which want a standalone instance should use `[MMEEventsManager.alloc sharedInit]` */
-describe(@"MMEventsManager.sharedManager", ^{
+describe(@"MMEEventsManager.sharedManager", ^{
     MMEEventsManager *allocated = [MMEEventsManager.alloc init];
 
     it(@"should be the sharedManager", ^{
@@ -102,7 +102,7 @@ describe(@"MMEventsManager.sharedManager", ^{
 
 /* this test shows how to create a custom subclass of MMEventsManager and get
     a standalone instace of it by using the private `initShared` initilizer */
-describe(@"MMEventsManager subclass for testing", ^{
+describe(@"MMEEventsManager subclass for testing", ^{
     MMEEventsManagerSubclass *subclass = [MMEEventsManagerSubclass.alloc initShared];
 
     it (@"should not be the sharedManager", ^{


### PR DESCRIPTION
Working on fixing the Carthage build as well, here's an example of how to use `initShared` in tests for subclasses and standalone instance of the `MMEEventsManager`