### PR TITLE
Deprecate gesture event collection

### DIFF
--- a/MapboxMobileEvents/MMEConstants.h
+++ b/MapboxMobileEvents/MMEConstants.h
@@ -43,16 +43,6 @@ extern NSString * const MMEEventTypeLocalDebug;
 extern NSString * const MMEventTypeOfflineDownloadStart;
 extern NSString * const MMEventTypeOfflineDownloadEnd;
 
-// Gestures
-extern NSString * const MMEEventGestureSingleTap;
-extern NSString * const MMEEventGestureDoubleTap;
-extern NSString * const MMEEventGestureTwoFingerSingleTap;
-extern NSString * const MMEEventGestureQuickZoom;
-extern NSString * const MMEEventGesturePanStart;
-extern NSString * const MMEEventGesturePinchStart;
-extern NSString * const MMEEventGestureRotateStart;
-extern NSString * const MMEEventGesturePitchStart;
-
 // Event keys
 extern NSString * const MMEEventKeyArrivalDate;
 extern NSString * const MMEEventKeyDepartureDate;
@@ -61,7 +51,6 @@ extern NSString * const MMEEventKeyLongitude;
 extern NSString * const MMEEventKeyZoomLevel;
 extern NSString * const MMEEventKeyMaxZoomLevel;
 extern NSString * const MMEEventKeyMinZoomLevel;
-extern NSString * const MMEEventKeyGestureId;
 extern NSString * const MMEEventKeyEvent;
 extern NSString * const MMEEventKeyCreated;
 extern NSString * const MMEEventKeyStyleURL;
@@ -181,10 +170,19 @@ extern NSString * const MMEErrorUnderlyingExceptionKey;
 #pragma mark - Deprecated
 
 extern NSString * const MMEEventKeyVendorID MME_DEPRECATED_MSG("Use MMEEventKeyVendorId");
-extern NSString * const MMEEventKeyGestureID MME_DEPRECATED_MSG("Use MMEEventKeyGestureId");
 extern NSString * const MMEEventKeyInstallationID MME_DEPRECATED_MSG("Use MMEEventKeyInstallationId");
 extern NSString * const MMEEventKeyAppID MME_DEPRECATED_MSG("Use MMEEventKeyInstallationId");
 
 extern NSString * const MMELoggerHTML MME_DEPRECATED;
 extern NSString * const MMELoggerShareableHTML MME_DEPRECATED;
 
+extern NSString * const MMEEventKeyGestureId MME_DEPRECATED;
+extern NSString * const MMEEventKeyGestureID MME_DEPRECATED;
+extern NSString * const MMEEventGestureSingleTap MME_DEPRECATED;
+extern NSString * const MMEEventGestureDoubleTap MME_DEPRECATED;
+extern NSString * const MMEEventGestureTwoFingerSingleTap MME_DEPRECATED;
+extern NSString * const MMEEventGestureQuickZoom MME_DEPRECATED;
+extern NSString * const MMEEventGesturePanStart MME_DEPRECATED;
+extern NSString * const MMEEventGesturePinchStart MME_DEPRECATED;
+extern NSString * const MMEEventGestureRotateStart MME_DEPRECATED;
+extern NSString * const MMEEventGesturePitchStart MME_DEPRECATED;

--- a/MapboxMobileEvents/MMEConstants.m
+++ b/MapboxMobileEvents/MMEConstants.m
@@ -41,15 +41,6 @@ NSString * const MMEEventTypeMapDragEnd = @"map.dragend";
 NSString * const MMEventTypeOfflineDownloadStart = @"map.offlineDownload.start";
 NSString * const MMEventTypeOfflineDownloadEnd = @"map.offlineDownload.end";
 
-NSString * const MMEEventGestureSingleTap = @"SingleTap";
-NSString * const MMEEventGestureDoubleTap = @"DoubleTap";
-NSString * const MMEEventGestureTwoFingerSingleTap = @"TwoFingerTap";
-NSString * const MMEEventGestureQuickZoom = @"QuickZoom";
-NSString * const MMEEventGesturePanStart = @"Pan";
-NSString * const MMEEventGesturePinchStart = @"Pinch";
-NSString * const MMEEventGestureRotateStart = @"Rotation";
-NSString * const MMEEventGesturePitchStart = @"Pitch";
-
 NSString * const MMEEventKeyArrivalDate = @"arrivalDate";
 NSString * const MMEEventKeyDepartureDate = @"departureDate";
 NSString * const MMEEventKeyLatitude = @"lat";
@@ -60,7 +51,6 @@ NSString * const MMEEventKeyZoomLevel = @"zoom";
 NSString * const MMEEventKeySpeed = @"speed";
 NSString * const MMEEventKeyStyleURL = @"styleURL";
 NSString * const MMEEventKeyCourse = @"course";
-NSString * const MMEEventKeyGestureId = @"gesture";
 NSString * const MMEEventHorizontalAccuracy = @"horizontalAccuracy";
 NSString * const MMEEventKeyLocalDebugDescription = @"debug.description";
 NSString * const MMEEventKeyErrorCode = @"error.code";
@@ -161,7 +151,6 @@ NSString * const MMEErrorUnderlyingExceptionKey = @"underlyingException";
 
 #pragma mark - Deprecated
 
-NSString * const MMEEventKeyGestureID = MMEEventKeyGestureId;
 NSString * const MMEEventKeyVendorID = MMEEventKeyVendorId;
 NSString * const MMEEventKeyInstallationID = MMEEventKeyInstallationId;
 NSString * const MMEEventKeyAppID = MMEEventKeyAppId;
@@ -170,3 +159,13 @@ NSString * const MMELoggerHTML = @"<html><head><script type='text/javascript' sr
 
 NSString * const MMELoggerShareableHTML = @"<html><head><script type='text/javascript' src='https://www.gstatic.com/charts/loader.js'></script><script type='text/javascript'>google.charts.load('current', {'packages':['timeline']});var container = document.getElementById('timeline-tooltip');var dataString;function addData(data) {dataString = data};google.charts.setOnLoadCallback(drawChart); function drawChart() {var dataTable = new google.visualization.DataTable({cols: [{id: 'eventType', label: 'Event Type', type: 'string'},{id: 'instance', type: 'string'},{type: 'string', role: 'tooltip', p:{html:true}},{id: 'start', label: 'Event Start Time', type: 'datetime'},{id: 'end', label: 'Event End Time', type: 'datetime'}],rows: dataString});var options = {'title':'Telemetry Log Data','width':1024,'height':400,'timeline': { groupByRowLabel: true },tooltip: {isHtml: true}};var chart = new google.visualization.Timeline(document.getElementById('chart_div'));google.visualization.events.addListener(chart, 'ready', afterDraw);chart.draw(dataTable, options);}function afterDraw() {}</script></head><body><div id=\"timeline-tooltip\" style=\"height: 180px;\"></div><div id='chart_div'></div></body></html>";
 
+NSString * const MMEEventKeyGestureId = @"gesture";
+NSString * const MMEEventKeyGestureID = MMEEventKeyGestureId;
+NSString * const MMEEventGestureSingleTap = @"SingleTap";
+NSString * const MMEEventGestureDoubleTap = @"DoubleTap";
+NSString * const MMEEventGestureTwoFingerSingleTap = @"TwoFingerTap";
+NSString * const MMEEventGestureQuickZoom = @"QuickZoom";
+NSString * const MMEEventGesturePanStart = @"Pan";
+NSString * const MMEEventGesturePinchStart = @"Pinch";
+NSString * const MMEEventGestureRotateStart = @"Rotation";
+NSString * const MMEEventGesturePitchStart = @"Pitch";

--- a/MapboxMobileEvents/MMENamespacedDependencies.h
+++ b/MapboxMobileEvents/MMENamespacedDependencies.h
@@ -357,38 +357,6 @@
 #define MMEventTypeOfflineDownloadEnd __NS_SYMBOL(MMEventTypeOfflineDownloadEnd)
 #endif
 
-#ifndef MMEEventGestureSingleTap
-#define MMEEventGestureSingleTap __NS_SYMBOL(MMEEventGestureSingleTap)
-#endif
-
-#ifndef MMEEventGestureDoubleTap
-#define MMEEventGestureDoubleTap __NS_SYMBOL(MMEEventGestureDoubleTap)
-#endif
-
-#ifndef MMEEventGestureTwoFingerSingleTap
-#define MMEEventGestureTwoFingerSingleTap __NS_SYMBOL(MMEEventGestureTwoFingerSingleTap)
-#endif
-
-#ifndef MMEEventGestureQuickZoom
-#define MMEEventGestureQuickZoom __NS_SYMBOL(MMEEventGestureQuickZoom)
-#endif
-
-#ifndef MMEEventGesturePanStart
-#define MMEEventGesturePanStart __NS_SYMBOL(MMEEventGesturePanStart)
-#endif
-
-#ifndef MMEEventGesturePinchStart
-#define MMEEventGesturePinchStart __NS_SYMBOL(MMEEventGesturePinchStart)
-#endif
-
-#ifndef MMEEventGestureRotateStart
-#define MMEEventGestureRotateStart __NS_SYMBOL(MMEEventGestureRotateStart)
-#endif
-
-#ifndef MMEEventGesturePitchStart
-#define MMEEventGesturePitchStart __NS_SYMBOL(MMEEventGesturePitchStart)
-#endif
-
 #ifndef MMEEventKeyArrivalDate
 #define MMEEventKeyArrivalDate __NS_SYMBOL(MMEEventKeyArrivalDate)
 #endif
@@ -427,10 +395,6 @@
 
 #ifndef MMEEventKeyCourse
 #define MMEEventKeyCourse __NS_SYMBOL(MMEEventKeyCourse)
-#endif
-
-#ifndef MMEEventKeyGestureId
-#define MMEEventKeyGestureId __NS_SYMBOL(MMEEventKeyGestureId)
 #endif
 
 #ifndef MMEEventHorizontalAccuracy
@@ -777,10 +741,6 @@
 #define MMEErrorUnderlyingExceptionKey __NS_SYMBOL(MMEErrorUnderlyingExceptionKey)
 #endif
 
-#ifndef MMEEventKeyGestureID
-#define MMEEventKeyGestureID __NS_SYMBOL(MMEEventKeyGestureID)
-#endif
-
 #ifndef MMEEventKeyVendorID
 #define MMEEventKeyVendorID __NS_SYMBOL(MMEEventKeyVendorID)
 #endif
@@ -799,6 +759,46 @@
 
 #ifndef MMELoggerShareableHTML
 #define MMELoggerShareableHTML __NS_SYMBOL(MMELoggerShareableHTML)
+#endif
+
+#ifndef MMEEventKeyGestureId
+#define MMEEventKeyGestureId __NS_SYMBOL(MMEEventKeyGestureId)
+#endif
+
+#ifndef MMEEventKeyGestureID
+#define MMEEventKeyGestureID __NS_SYMBOL(MMEEventKeyGestureID)
+#endif
+
+#ifndef MMEEventGestureSingleTap
+#define MMEEventGestureSingleTap __NS_SYMBOL(MMEEventGestureSingleTap)
+#endif
+
+#ifndef MMEEventGestureDoubleTap
+#define MMEEventGestureDoubleTap __NS_SYMBOL(MMEEventGestureDoubleTap)
+#endif
+
+#ifndef MMEEventGestureTwoFingerSingleTap
+#define MMEEventGestureTwoFingerSingleTap __NS_SYMBOL(MMEEventGestureTwoFingerSingleTap)
+#endif
+
+#ifndef MMEEventGestureQuickZoom
+#define MMEEventGestureQuickZoom __NS_SYMBOL(MMEEventGestureQuickZoom)
+#endif
+
+#ifndef MMEEventGesturePanStart
+#define MMEEventGesturePanStart __NS_SYMBOL(MMEEventGesturePanStart)
+#endif
+
+#ifndef MMEEventGesturePinchStart
+#define MMEEventGesturePinchStart __NS_SYMBOL(MMEEventGesturePinchStart)
+#endif
+
+#ifndef MMEEventGestureRotateStart
+#define MMEEventGestureRotateStart __NS_SYMBOL(MMEEventGestureRotateStart)
+#endif
+
+#ifndef MMEEventGesturePitchStart
+#define MMEEventGesturePitchStart __NS_SYMBOL(MMEEventGesturePitchStart)
 #endif
 
 #ifndef kMMEMaxRequestCount


### PR DESCRIPTION
Deprecates gesture event keys, as the only downstream client (AFAIK) of these no longer uses them since https://github.com/mapbox/mapbox-gl-native/pull/14579.

/cc @alfwatt @rclee 