### PR TITLE
Specify "use credential" option for handling auth challenges for excluded domains

### DIFF
--- a/MapboxMobileEvents/MMECertPin.m
+++ b/MapboxMobileEvents/MMECertPin.m
@@ -86,8 +86,8 @@
         for (NSString *excludeSubdomains in _excludeSubdomainsSet) {
             if ([challenge.protectionSpace.host isEqualToString:excludeSubdomains]) {
                 dispatch_async(dispatch_get_main_queue(), ^{
-                    self.lastAuthChallengeDisposition = NSURLSessionAuthChallengePerformDefaultHandling;
-                    completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
+                    self.lastAuthChallengeDisposition = NSURLSessionAuthChallengeUseCredential;
+                    completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
                 });
                 
                 NSString *debugDescription = [NSString stringWithFormat:@"Excluded subdomain(s): %@", excludeSubdomains];


### PR DESCRIPTION
This is an experimental change which was required in order to use exclude specific domain from checking certificate pinning.
With a previous setup I had a following error message on turnstile event sending:
```
2019-07-09 01:42:58.148325+0300 demo[1372:268452] TIC SSL Trust Error [5:0x282d26ac0]: 3:0
2019-07-09 01:42:58.230279+0300 demo[1372:268452] NSURLSession/NSURLConnection HTTP load failed (kCFStreamErrorDomainSSL, -9843)
2019-07-09 01:42:58.230355+0300 demo[1372:268452] Task <6D02725B-B9BE-48B9-856E-725E1BAFC826>.<3> HTTP load failed (error code: -1202 [3:-9843])
2019-07-09 01:42:58.230641+0300 demo[1372:268366] Task <6D02725B-B9BE-48B9-856E-725E1BAFC826>.<3> finished with error - code: -1202
2019-07-09 01:42:58.266652+0300 demo[1372:268191] Mapbox Telemetry event <MMEEvent name=debug, date=2019-07-08 22:42:58 +0000, attributes={
    created = "2019-07-08T22:42:58.267+0000";
    "debug.description" = "Could not send turnstile event: Error Domain=NSURLErrorDomain Code=-1202 \"The certificate for this server is invalid. You might be connecting to a server that is pretending to be \U201c<EXCLUDED_DOMAIN>\U201d which could put your confidential information at risk.\" UserInfo={NSURLErrorFailingURLPeerTrustErrorKey=<SecTrustRef: 0x282a1e250>, NSLocalizedRecoverySuggestion=Would you like to connect to the server anyway?, _kCFStreamErrorDomainKey=3, _kCFStreamErrorCodeKey=-9843, NSErrorPeerCertificateChainKey=(\n    \"<cert(0x10c8b8400) s: events.mapbox.cn i: GeoTrust RSA CA 2018>\",\n    \"<cert(0x10c0a5a00) s: GeoTrust RSA CA 2018 i: DigiCert Global Root CA>\"\n), NSUnderlyingError=0x2816f02d0 {Error Domain=kCFErrorDomainCFNetwork Code=-1202 \"(null)\" UserInfo={_kCFStreamPropertySSLClientCertificateState=0, kCFStreamPropertySSLPeerTrust=<SecTrustRef: 0x282a1e250>, _kCFNetworkCFStreamSSLErrorOriginalValue=-9843, _kCFStreamErrorDomainKey=3, _kCFStreamErrorCodeKey=-9843, kCFStreamPropertySSLPeerCertificates=(\n    \"<cert(0x10c8b8400) s: events.mapbox.cn i: GeoTrust RSA CA 2018>\",\n    \"<cert(0x10c0a5a00) s: GeoTrust RSA CA 2018 i: DigiCert Global Root CA>\"\n)}}, NSLocalizedDescription=The certificate for this server is invalid. You might be connecting to a server that is pretending to be \U201c<EXCLUDED_DOMAIN>\U201d which could put your confidential information at risk., NSErrorFailingURLKey=https://<EXCLUDED_DOMAIN>/events/v2?access_token=<ACCESS_TOKEN>, NSErrorFailingURLStringKey=https://<EXCLUDED_DOMAIN>/events/v2?access_token=<ACCESS_TOKEN>, NSErrorClientCertificateStateKey=0}";
    "debug.type" = turnstile;
    event = debug;
    instance = "61D349E8-6069-4083-B083-727C7ACAC877";
}>
```

Providing credentials solved the issue and allowed turnstile event and all the following requests succeed.