### PR TITLE
[WIP] Refactor debug events 

### DIFF
--- a/MapboxMobileEvents/MMEAPIClient.m
+++ b/MapboxMobileEvents/MMEAPIClient.m
@@ -4,7 +4,7 @@
 #import "MMEEvent.h"
 #import "NSData+MMEGZIP.h"
 #import "MMEMetricsManager.h"
-#import "MMEEventsManager.h"
+#import "MMEEventLogger.h"
 
 typedef NS_ENUM(NSInteger, MMEErrorCode) {
     MMESessionFailedError,
@@ -12,12 +12,6 @@ typedef NS_ENUM(NSInteger, MMEErrorCode) {
 };
 
 @import MobileCoreServices;
-
-#pragma mark -
-
-@interface MMEEventsManager (Private)
-- (void)pushEvent:(MMEEvent *)event;
-@end
 
 #pragma mark -
 
@@ -264,7 +258,7 @@ int const kMMEMaxRequestCount = 1000;
             [request setHTTPBody:jsonData];
         }
     } else if (jsonError) {
-        [[MMEEventsManager sharedManager] pushEvent:[MMEEvent debugEventWithError:jsonError]];
+        [MMEEventLogger.sharedLogger logEvent:[MMEEvent debugEventWithError:jsonError]];
 
         return nil;
     }
@@ -299,7 +293,7 @@ int const kMMEMaxRequestCount = 1000;
         [httpBody appendData:jsonData];
         [httpBody appendData:[[NSString stringWithFormat:@"\r\n\r\n"] dataUsingEncoding:NSUTF8StringEncoding]];
     } else if (jsonError) {
-        [[MMEEventsManager sharedManager] pushEvent:[MMEEvent debugEventWithError:jsonError]];
+        [MMEEventLogger.sharedLogger logEvent:[MMEEvent debugEventWithError:jsonError]];
     }
 
     for (NSString *path in filePaths) { // add a file part for each

--- a/MapboxMobileEvents/MMEEvent.h
+++ b/MapboxMobileEvents/MMEEvent.h
@@ -61,7 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
 */
 + (instancetype)crashEventReporting:(NSError *)eventsError error:(NSError **)createError;
 
-#pragma mark - Debug Devents
+#pragma mark - Debug Events
 
 /*! @brief debugEventWithAttributes: debug logging event with attributes provided
     @param attributes attrs

--- a/MapboxMobileEvents/MMEEvent.h
+++ b/MapboxMobileEvents/MMEEvent.h
@@ -75,7 +75,7 @@ NS_ASSUME_NONNULL_BEGIN
 */
 + (instancetype)debugEventWithError:(NSError *)error MME_DEPRECATED;
 
-/*! @brief debugEventWithException: debug logging event the the exception provided
+/*! @brief debugEventWithException: debug logging event with the exception provided
     @param except exception
     @return event
 */

--- a/MapboxMobileEvents/MMEEventsManager.m
+++ b/MapboxMobileEvents/MMEEventsManager.m
@@ -420,7 +420,7 @@
             __strong __typeof__(weakSelf) strongSelf = weakSelf;
 
             if (error) {
-                [strongSelf pushEvent:[MMEEvent debugEventWithError:error]];
+                [MMEEventLogger.sharedLogger logEvent:[MMEEvent debugEventWithError:error]];
                 return;
             }
 
@@ -544,7 +544,7 @@
             [self pushEvent:errorEvent];
         }
         else {
-            [self pushEvent:[MMEEvent debugEventWithError:createError]];
+            [MMEEventLogger.sharedLogger logEvent:[MMEEvent debugEventWithError:createError]];
         }
     }
     @catch(NSException *except) {

--- a/MapboxMobileEvents/MMEMetricsManager.m
+++ b/MapboxMobileEvents/MMEMetricsManager.m
@@ -318,7 +318,7 @@
         if (jsonData) {
             jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
         } else if (jsonError) {
-            [[MMEEventsManager sharedManager] pushEvent:[MMEEvent debugEventWithError:jsonError]];
+            [MMEEventLogger.sharedLogger logEvent:[MMEEvent debugEventWithError:jsonError]];
         }
         return jsonString;
     }

--- a/MapboxMobileEvents/MMENSURLSessionWrapper.m
+++ b/MapboxMobileEvents/MMENSURLSessionWrapper.m
@@ -2,6 +2,7 @@
 #import "MMEEventsManager.h"
 #import "MMECertPin.h"
 #import "MMEEvent.h"
+#import "MMEEventLogger.h"
 
 #pragma mark -
 
@@ -68,7 +69,7 @@
 -(void)URLSession:(NSURLSession *)session didBecomeInvalidWithError:(NSError *)error {
     if (error) { // only recreate the session if the error was non-nil
         self.session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration] delegate:self delegateQueue:nil];
-        [[MMEEventsManager sharedManager] pushEvent:[MMEEvent debugEventWithError:error]];
+        [MMEEventLogger.sharedLogger logEvent:[MMEEvent debugEventWithError:error]];
     }
     else { // release the session object
         self.session = nil;

--- a/MapboxMobileEventsTests/MMEEventsManagerTests.mm
+++ b/MapboxMobileEventsTests/MMEEventsManagerTests.mm
@@ -1074,7 +1074,8 @@ describe(@"MMEEventsManager", ^{
             }];
 
             it(@"should not queue error events", ^{
-                [eventsManager pushEvent:[MMEEvent debugEventWithError:testError]];
+                MMEEvent *errorEvent = [MMEEvent debugEventWithError:testError];
+                [eventsManager pushEvent:errorEvent];
                 eventsManager.eventQueue.count should equal(0);
             });
         });
@@ -1083,7 +1084,8 @@ describe(@"MMEEventsManager", ^{
             NSException *testException = [NSException.alloc initWithName:@"TestExceptionName" reason:@"TestExceptionReason" userInfo:nil];
 
             it(@"should not queue exception events", ^{
-                [eventsManager pushEvent:[MMEEvent debugEventWithException:testException]];
+                MMEEvent *exceptionEvent = [MMEEvent debugEventWithException:testException];
+                [eventsManager pushEvent:exceptionEvent];
                 eventsManager.eventQueue.count should equal(0);
             });
         });

--- a/MapboxMobileEventsTests/MMEEventsManagerTests.mm
+++ b/MapboxMobileEventsTests/MMEEventsManagerTests.mm
@@ -74,12 +74,12 @@ static CLLocation * location() {
 SPEC_BEGIN(MMEEventsManagerSpec)
 
 /* many of the tests use a manager which is not the shared manager,
-   in normal operation clietns should not use the private initShared method used for testsing */
-describe(@"MMEventsManager.sharedManager", ^{
+   in normal operation clietns should not use the private initShared method used for testing */
+describe(@"MMEEventsManager.sharedManager", ^{
     MMEEventsManager *shared = MMEEventsManager.sharedManager;
     MMEEventsManager *allocated = [MMEEventsManager.alloc init];
 
-    it(@"", ^{
+    it(@"should equal the allocated manager", ^{
         shared should equal(allocated);
     });
 });
@@ -421,7 +421,7 @@ describe(@"MMEEventsManager", ^{
                                 spy_on(timerManager);
                                 timerManager.target = eventsManager;
                                 timerManager.selector = @selector(sendTelemetryMetricsEvent);
-                                MMEEventsManager.sharedManager.timerManager = timerManager;
+                                eventsManager.timerManager = timerManager;
                                 [timerManager triggerTimer];
                             });
                             
@@ -436,7 +436,7 @@ describe(@"MMEEventsManager", ^{
                                 spy_on(timerManager);
                                 timerManager.target = eventsManager;
                                 timerManager.selector = @selector(flush);
-                                MMEEventsManager.sharedManager.timerManager = timerManager;
+                                eventsManager.timerManager = timerManager;
                                 [timerManager triggerTimer];
                             });
                             
@@ -1068,22 +1068,22 @@ describe(@"MMEEventsManager", ^{
         });
 
         context(@"when an error event is pushed", ^{
-            NSError* testError = [NSError.alloc initWithDomain:NSCocoaErrorDomain code:999 userInfo:@{
+            NSError *testError = [NSError.alloc initWithDomain:NSCocoaErrorDomain code:999 userInfo:@{
                 NSLocalizedDescriptionKey: @"Test Error Description",
                 NSLocalizedFailureReasonErrorKey: @"Test Error Failure Reason"
             }];
 
             it(@"should not queue error events", ^{
-                [MMEEventsManager.sharedManager pushEvent:[MMEEvent debugEventWithError:testError]];
+                [eventsManager pushEvent:[MMEEvent debugEventWithError:testError]];
                 eventsManager.eventQueue.count should equal(0);
             });
         });
 
         context(@"when an exception event is pushed", ^{
-            NSException* testException = [NSException.alloc initWithName:@"TestExceptionName" reason:@"TestExceptionReason" userInfo:nil];
+            NSException *testException = [NSException.alloc initWithName:@"TestExceptionName" reason:@"TestExceptionReason" userInfo:nil];
 
             it(@"should not queue exception events", ^{
-                [MMEEventsManager.sharedManager pushEvent:[MMEEvent debugEventWithException:testException]];
+                [eventsManager pushEvent:[MMEEvent debugEventWithException:testException]];
                 eventsManager.eventQueue.count should equal(0);
             });
         });


### PR DESCRIPTION
`MMEEventsManager.sharedManager` was not allowing for the events to be queued in the tests.

Further changes may be needed where debug events are found.