### PR TITLE
Fix compilation error on case-sensitive file system

### DIFF
--- a/MapboxMobileEvents/MMEMetrics.h
+++ b/MapboxMobileEvents/MMEMetrics.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#import <CoreLocation/Corelocation.h>
+#import <CoreLocation/CoreLocation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
Fix the typo of "L" letter of the CoreLocation header filename. This is causing building
failure on OS X with file system which is case-sensitive.