### PR TITLE
🧹 Synchronize dynamic and static targets

### DIFF
--- a/MapboxMobileEvents.xcodeproj/project.pbxproj
+++ b/MapboxMobileEvents.xcodeproj/project.pbxproj
@@ -109,6 +109,7 @@
 		9C3F93562351300F00F99907 /* MMEExceptionalDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C3F93532351300F00F99907 /* MMEExceptionalDictionary.m */; platformFilter = ios; };
 		9C3F93582351317F00F99907 /* MMEAPIConfigTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C3F93572351317F00F99907 /* MMEAPIConfigTests.m */; platformFilter = ios; };
 		9C3F935B235138FD00F99907 /* MMETestDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C3F9359235138FD00F99907 /* MMETestDelegate.m */; };
+		9C5B4CD7237104D000FB283C /* libMapboxMobileEvents.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 408596531ED084C0003BD29D /* libMapboxMobileEvents.a */; };
 		9C65A2702256C110006E3FED /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9C65A26E2256C110006E3FED /* Main.storyboard */; };
 		9C65A2722256C112006E3FED /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9C65A2712256C112006E3FED /* Assets.xcassets */; };
 		9C65A2752256C112006E3FED /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9C65A2732256C112006E3FED /* LaunchScreen.storyboard */; };
@@ -153,6 +154,30 @@
 		9CE132CC235A7F8B005E23F1 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9C794C85235505340027B9D4 /* XCTest.framework */; };
 		9CF00039236FDD67009A2700 /* Cedar.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 40A7F9911F79A743002B931F /* Cedar.framework */; };
 		9CF0003A236FDD6D009A2700 /* Cedar.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 40A7F9911F79A743002B931F /* Cedar.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9CF00044237102B8009A2700 /* NSUserDefaults+MMEConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 9CDC34B7234FD35800852FF0 /* NSUserDefaults+MMEConfiguration.m */; platformFilter = ios; };
+		9CF000492371037E009A2700 /* MMETestDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C3F9359235138FD00F99907 /* MMETestDelegate.m */; };
+		9CF0004C2371037E009A2700 /* Cedar.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 40A7F9911F79A743002B931F /* Cedar.framework */; };
+		9CF0004E2371037E009A2700 /* events-201.json in Resources */ = {isa = PBXBuildFile; fileRef = 9C3F933C23512FD300F99907 /* events-201.json */; };
+		9CF0004F2371037E009A2700 /* config-10000m-gfo.json in Resources */ = {isa = PBXBuildFile; fileRef = 9C3F933623512FD200F99907 /* config-10000m-gfo.json */; };
+		9CF000502371037E009A2700 /* config-test-tag.json in Resources */ = {isa = PBXBuildFile; fileRef = 9C3F934323512FD300F99907 /* config-test-tag.json */; };
+		9CF000512371037E009A2700 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9C65A2732256C112006E3FED /* LaunchScreen.storyboard */; };
+		9CF000522371037E009A2700 /* config-1000m-gfo.json in Resources */ = {isa = PBXBuildFile; fileRef = 9C3F934223512FD300F99907 /* config-1000m-gfo.json */; };
+		9CF000532371037E009A2700 /* config-all-wrong.json in Resources */ = {isa = PBXBuildFile; fileRef = 9C3F934123512FD300F99907 /* config-all-wrong.json */; };
+		9CF000542371037E009A2700 /* config-100s-bso.json in Resources */ = {isa = PBXBuildFile; fileRef = 9C3F933823512FD300F99907 /* config-100s-bso.json */; };
+		9CF000552371037E009A2700 /* config-long-ago.json in Resources */ = {isa = PBXBuildFile; fileRef = 9CE132C32358EC25005E23F1 /* config-long-ago.json */; };
+		9CF000562371037E009A2700 /* config-null-tag.json in Resources */ = {isa = PBXBuildFile; fileRef = 9C3F933E23512FD300F99907 /* config-null-tag.json */; };
+		9CF000572371037E009A2700 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9C65A2712256C112006E3FED /* Assets.xcassets */; };
+		9CF000582371037E009A2700 /* config-1s-bso.json in Resources */ = {isa = PBXBuildFile; fileRef = 9C3F933F23512FD300F99907 /* config-1s-bso.json */; };
+		9CF000592371037E009A2700 /* config-crl.json in Resources */ = {isa = PBXBuildFile; fileRef = 9CE132C62359296A005E23F1 /* config-crl.json */; };
+		9CF0005A2371037E009A2700 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9C65A26E2256C110006E3FED /* Main.storyboard */; };
+		9CF0005B2371037E009A2700 /* config-null.json in Resources */ = {isa = PBXBuildFile; fileRef = 9C3F933723512FD200F99907 /* config-null.json */; };
+		9CF0005C2371037E009A2700 /* config-10s-bso.json in Resources */ = {isa = PBXBuildFile; fileRef = 9C3F933523512FD200F99907 /* config-10s-bso.json */; };
+		9CF0005D2371037E009A2700 /* config-type2-tto.json in Resources */ = {isa = PBXBuildFile; fileRef = 9C3F933D23512FD300F99907 /* config-type2-tto.json */; };
+		9CF0005E2371037E009A2700 /* config-all.json in Resources */ = {isa = PBXBuildFile; fileRef = 9C3F933B23512FD300F99907 /* config-all.json */; };
+		9CF0005F2371037E009A2700 /* config-number-tag.json in Resources */ = {isa = PBXBuildFile; fileRef = 9C3F933A23512FD300F99907 /* config-number-tag.json */; };
+		9CF000602371037E009A2700 /* config-type1-tto.json in Resources */ = {isa = PBXBuildFile; fileRef = 9C3F933923512FD300F99907 /* config-type1-tto.json */; };
+		9CF000612371037E009A2700 /* config-100m-gfo.json in Resources */ = {isa = PBXBuildFile; fileRef = 9C3F934023512FD300F99907 /* config-100m-gfo.json */; };
+		9CF000642371037E009A2700 /* Cedar.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 40A7F9911F79A743002B931F /* Cedar.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		AC1B091122137BB000DB56C8 /* CLLocationManager+MMEMobileEvents.h in Headers */ = {isa = PBXBuildFile; fileRef = AC1B090F22137BB000DB56C8 /* CLLocationManager+MMEMobileEvents.h */; };
 		AC1B091222137BB000DB56C8 /* CLLocationManager+MMEMobileEvents.m in Sources */ = {isa = PBXBuildFile; fileRef = AC1B091022137BB000DB56C8 /* CLLocationManager+MMEMobileEvents.m */; };
 		AC1B091322137BB000DB56C8 /* CLLocationManager+MMEMobileEvents.m in Sources */ = {isa = PBXBuildFile; fileRef = AC1B091022137BB000DB56C8 /* CLLocationManager+MMEMobileEvents.m */; platformFilter = ios; };
@@ -211,6 +236,13 @@
 			remoteGlobalIDString = 408596521ED084C0003BD29D;
 			remoteInfo = MapboxMobileEventsStatic;
 		};
+		9CF0006A23710389009A2700 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 404807B01EA186D8008A6D50 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 408596521ED084C0003BD29D;
+			remoteInfo = libMapboxMobileEvents;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -220,11 +252,11 @@
 			dstPath = include/MapboxMobileEvents;
 			dstSubfolderSpec = 16;
 			files = (
-				40F16C901F042F2A00DF338D /* MMETypes.h in CopyFiles */,
+				4085966A1ED08FA9003BD29D /* MapboxMobileEvents.h in CopyFiles */,
 				408596DA1ED0BF35003BD29D /* MMEConstants.h in CopyFiles */,
 				408596D81ED0B1F6003BD29D /* MMEEvent.h in CopyFiles */,
 				408596D91ED0B1F6003BD29D /* MMEEventsManager.h in CopyFiles */,
-				4085966A1ED08FA9003BD29D /* MapboxMobileEvents.h in CopyFiles */,
+				40F16C901F042F2A00DF338D /* MMETypes.h in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -236,6 +268,17 @@
 			files = (
 				9C65A2802256C1CF006E3FED /* MapboxMobileEvents.framework in Embed Frameworks */,
 				9CF0003A236FDD6D009A2700 /* Cedar.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9CF000622371037E009A2700 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				9CF000642371037E009A2700 /* Cedar.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -271,7 +314,6 @@
 		4052C4F21EFB4A740044E2FF /* MMETimerManagerFake.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MMETimerManagerFake.m; sourceTree = "<group>"; };
 		40834B9E1FDF62C900C1BD0D /* MMENamespacedDependencies.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MMENamespacedDependencies.h; sourceTree = "<group>"; };
 		408596531ED084C0003BD29D /* libMapboxMobileEvents.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libMapboxMobileEvents.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		408596711ED08FF7003BD29D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		409115331F16BCD200F4250B /* MMECategoryLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MMECategoryLoader.h; sourceTree = "<group>"; };
 		409115341F16BCD200F4250B /* MMECategoryLoader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MMECategoryLoader.m; sourceTree = "<group>"; };
 		40A7F9911F79A743002B931F /* Cedar.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cedar.framework; path = Carthage/Build/iOS/Cedar.framework; sourceTree = "<group>"; };
@@ -369,6 +411,7 @@
 		9CE132C62359296A005E23F1 /* config-crl.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "config-crl.json"; sourceTree = "<group>"; };
 		9CE132C8235A5296005E23F1 /* MMERunningLock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MMERunningLock.h; path = Utilities/MMERunningLock.h; sourceTree = "<group>"; };
 		9CE132C9235A5296005E23F1 /* MMERunningLock.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = MMERunningLock.m; path = Utilities/MMERunningLock.m; sourceTree = "<group>"; };
+		9CF000682371037E009A2700 /* MMETestHost (Static).app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "MMETestHost (Static).app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC1B090F22137BB000DB56C8 /* CLLocationManager+MMEMobileEvents.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CLLocationManager+MMEMobileEvents.h"; sourceTree = "<group>"; };
 		AC1B091022137BB000DB56C8 /* CLLocationManager+MMEMobileEvents.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "CLLocationManager+MMEMobileEvents.m"; sourceTree = "<group>"; };
 		AC2C715C21124089004179E0 /* MMEDispatchManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MMEDispatchManager.h; sourceTree = "<group>"; };
@@ -437,6 +480,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		9CF0004A2371037E009A2700 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9C5B4CD7237104D000FB283C /* libMapboxMobileEvents.a in Frameworks */,
+				9CF0004C2371037E009A2700 /* Cedar.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -461,7 +513,6 @@
 				4032F47C1F1FEDC6001C1FBD /* Frameworks */,
 				9C6D9882221F37A200679292 /* Packaging */,
 				404807BA1EA186D8008A6D50 /* Products */,
-				408596701ED08FF7003BD29D /* resources */,
 				9C65A2CB2282081A006E3FED /* scripts */,
 			);
 			sourceTree = "<group>";
@@ -474,6 +525,7 @@
 				408596531ED084C0003BD29D /* libMapboxMobileEvents.a */,
 				9C65A2662256C110006E3FED /* MMETestHost.app */,
 				9CDC34ED23502F8700852FF0 /* MMECedarTests.xctest */,
+				9CF000682371037E009A2700 /* MMETestHost (Static).app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -522,14 +574,6 @@
 				9C3F931623512F5D00F99907 /* Fixtures */,
 			);
 			path = Tests;
-			sourceTree = "<group>";
-		};
-		408596701ED08FF7003BD29D /* resources */ = {
-			isa = PBXGroup;
-			children = (
-				408596711ED08FF7003BD29D /* Info.plist */,
-			);
-			path = resources;
 			sourceTree = "<group>";
 		};
 		40AE58481EA80E5E0046B437 /* Utilities */ = {
@@ -731,6 +775,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				404807CA1EA186D8008A6D50 /* MapboxMobileEvents.h in Headers */,
+				40AE58561EA932DB0046B437 /* MMEConstants.h in Headers */,
+				40AE586D1EA95EDD0046B437 /* MMEEvent.h in Headers */,
+				40C9E27B1EA542BC00744FE7 /* MMEEventsManager.h in Headers */,
 				40C9E27F1EA5473F00744FE7 /* MMELocationManager.h in Headers */,
 				40F16C811F02DA9F00DF338D /* MMEDate.h in Headers */,
 				40AE584E1EA926710046B437 /* MMETypes.h in Headers */,
@@ -739,7 +786,6 @@
 				40AE585A1EA9373F0046B437 /* MMEUniqueIdentifier.h in Headers */,
 				AC1B091122137BB000DB56C8 /* CLLocationManager+MMEMobileEvents.h in Headers */,
 				409115351F16BCD200F4250B /* MMECategoryLoader.h in Headers */,
-				40AE58561EA932DB0046B437 /* MMEConstants.h in Headers */,
 				40AE585E1EA93B3A0046B437 /* MMECommonEventData.h in Headers */,
 				AC61FA5C217A04CC008519F5 /* MMEMetrics.h in Headers */,
 				40FB437C1EFAFAE900EC5BC0 /* MMETimerManager.h in Headers */,
@@ -752,13 +798,11 @@
 				405172DD1EAFFA9400F8CDA1 /* MMENSURLSessionWrapper.h in Headers */,
 				40AE58691EA953970046B437 /* CLLocation+MMEMobileEvents.h in Headers */,
 				403835021F7AF145004205B9 /* MMEDependencyManager.h in Headers */,
-				40AE586D1EA95EDD0046B437 /* MMEEvent.h in Headers */,
 				9C3F930D235128F500F99907 /* MMEEventsManager_Private.h in Headers */,
 				9C65A28B225D41F2006E3FED /* UIKit+MMEMobileEvents.h in Headers */,
 				AC86FE1D2169250000D1B89C /* MMEMetricsManager.h in Headers */,
 				ACE4F01A1FD6102100035880 /* MMEUINavigation.h in Headers */,
 				40834B9F1FDF62C900C1BD0D /* MMENamespacedDependencies.h in Headers */,
-				40C9E27B1EA542BC00744FE7 /* MMEEventsManager.h in Headers */,
 				40F16C961F04514100DF338D /* MMEReachability.h in Headers */,
 				9C3F930B2351180A00F99907 /* MMEAPIClient_Private.h in Headers */,
 			);
@@ -858,6 +902,25 @@
 			productReference = 9CDC34ED23502F8700852FF0 /* MMECedarTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		9CF000452371037E009A2700 /* MMETestHost (Static) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9CF000652371037E009A2700 /* Build configuration list for PBXNativeTarget "MMETestHost (Static)" */;
+			buildPhases = (
+				9CF000482371037E009A2700 /* Sources */,
+				9CF0004A2371037E009A2700 /* Frameworks */,
+				9CF0004D2371037E009A2700 /* Resources */,
+				9CF000622371037E009A2700 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				9CF0006B23710389009A2700 /* PBXTargetDependency */,
+			);
+			name = "MMETestHost (Static)";
+			productName = MMETestHost;
+			productReference = 9CF000682371037E009A2700 /* MMETestHost (Static).app */;
+			productType = "com.apple.product-type.application";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -921,6 +984,7 @@
 				404807C11EA186D8008A6D50 /* MMEXCTests */,
 				9CDC34C223502F8700852FF0 /* MMECedarTests */,
 				9C65A2652256C110006E3FED /* MMETestHost */,
+				9CF000452371037E009A2700 /* MMETestHost (Static) */,
 			);
 		};
 /* End PBXProject section */
@@ -974,6 +1038,33 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		9CF0004D2371037E009A2700 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9CF0004E2371037E009A2700 /* events-201.json in Resources */,
+				9CF0004F2371037E009A2700 /* config-10000m-gfo.json in Resources */,
+				9CF000502371037E009A2700 /* config-test-tag.json in Resources */,
+				9CF000512371037E009A2700 /* LaunchScreen.storyboard in Resources */,
+				9CF000522371037E009A2700 /* config-1000m-gfo.json in Resources */,
+				9CF000532371037E009A2700 /* config-all-wrong.json in Resources */,
+				9CF000542371037E009A2700 /* config-100s-bso.json in Resources */,
+				9CF000552371037E009A2700 /* config-long-ago.json in Resources */,
+				9CF000562371037E009A2700 /* config-null-tag.json in Resources */,
+				9CF000572371037E009A2700 /* Assets.xcassets in Resources */,
+				9CF000582371037E009A2700 /* config-1s-bso.json in Resources */,
+				9CF000592371037E009A2700 /* config-crl.json in Resources */,
+				9CF0005A2371037E009A2700 /* Main.storyboard in Resources */,
+				9CF0005B2371037E009A2700 /* config-null.json in Resources */,
+				9CF0005C2371037E009A2700 /* config-10s-bso.json in Resources */,
+				9CF0005D2371037E009A2700 /* config-type2-tto.json in Resources */,
+				9CF0005E2371037E009A2700 /* config-all.json in Resources */,
+				9CF0005F2371037E009A2700 /* config-number-tag.json in Resources */,
+				9CF000602371037E009A2700 /* config-type1-tto.json in Resources */,
+				9CF000612371037E009A2700 /* config-100m-gfo.json in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
@@ -998,32 +1089,32 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AC86FE1E2169250000D1B89C /* MMEMetricsManager.m in Sources */,
-				9CDC34B9234FD35800852FF0 /* NSUserDefaults+MMEConfiguration.m in Sources */,
-				ACE4F01B1FD6102100035880 /* MMEUINavigation.m in Sources */,
-				409115361F16BCD200F4250B /* MMECategoryLoader.m in Sources */,
-				40F16C821F02DA9F00DF338D /* MMEDate.m in Sources */,
-				AC2C715F2112408A004179E0 /* MMEDispatchManager.m in Sources */,
-				40C9E27C1EA542BC00744FE7 /* MMEEventsManager.m in Sources */,
-				40AE58571EA932DB0046B437 /* MMEConstants.m in Sources */,
-				AC61FA5D217A04CC008519F5 /* MMEMetrics.m in Sources */,
 				40AE586A1EA953970046B437 /* CLLocation+MMEMobileEvents.m in Sources */,
-				40AE58441EA6C86C0046B437 /* MMEUIApplicationWrapper.m in Sources */,
-				4036EFBF1ED37D56009C40BA /* MMEEventLogger.m in Sources */,
 				AC1B091222137BB000DB56C8 /* CLLocationManager+MMEMobileEvents.m in Sources */,
-				CF93A6582241EDD500BBA199 /* MMECertPin.m in Sources */,
-				40AE585F1EA93B3A0046B437 /* MMECommonEventData.m in Sources */,
-				40F133531F20051E007B4096 /* NSData+MMEGZIP.m in Sources */,
-				40FB437D1EFAFAE900EC5BC0 /* MMETimerManager.m in Sources */,
-				9C65A28C225D41F2006E3FED /* UIKit+MMEMobileEvents.m in Sources */,
-				403835031F7AF145004205B9 /* MMEDependencyManager.m in Sources */,
 				40AE58721EAA87960046B437 /* MMEAPIClient.m in Sources */,
-				40F16C971F04514100DF338D /* MMEReachability.m in Sources */,
-				40C9E2801EA5473F00744FE7 /* MMELocationManager.m in Sources */,
-				AC611F281FCDED2F00ABBF6D /* MMEEventLogReportViewController.m in Sources */,
-				405172DE1EAFFA9400F8CDA1 /* MMENSURLSessionWrapper.m in Sources */,
+				409115361F16BCD200F4250B /* MMECategoryLoader.m in Sources */,
+				CF93A6582241EDD500BBA199 /* MMECertPin.m in Sources */,
+				40AE58571EA932DB0046B437 /* MMEConstants.m in Sources */,
+				40AE585F1EA93B3A0046B437 /* MMECommonEventData.m in Sources */,
+				40F16C821F02DA9F00DF338D /* MMEDate.m in Sources */,
+				403835031F7AF145004205B9 /* MMEDependencyManager.m in Sources */,
+				AC2C715F2112408A004179E0 /* MMEDispatchManager.m in Sources */,
 				40AE586E1EA95EDD0046B437 /* MMEEvent.m in Sources */,
+				4036EFBF1ED37D56009C40BA /* MMEEventLogger.m in Sources */,
+				AC611F281FCDED2F00ABBF6D /* MMEEventLogReportViewController.m in Sources */,
+				40C9E27C1EA542BC00744FE7 /* MMEEventsManager.m in Sources */,
+				40C9E2801EA5473F00744FE7 /* MMELocationManager.m in Sources */,
+				AC61FA5D217A04CC008519F5 /* MMEMetrics.m in Sources */,
+				AC86FE1E2169250000D1B89C /* MMEMetricsManager.m in Sources */,
+				405172DE1EAFFA9400F8CDA1 /* MMENSURLSessionWrapper.m in Sources */,
+				40F16C971F04514100DF338D /* MMEReachability.m in Sources */,
+				40FB437D1EFAFAE900EC5BC0 /* MMETimerManager.m in Sources */,
+				40AE58441EA6C86C0046B437 /* MMEUIApplicationWrapper.m in Sources */,
+				ACE4F01B1FD6102100035880 /* MMEUINavigation.m in Sources */,
 				40AE585B1EA9373F0046B437 /* MMEUniqueIdentifier.m in Sources */,
+				40F133531F20051E007B4096 /* NSData+MMEGZIP.m in Sources */,
+				9CDC34B9234FD35800852FF0 /* NSUserDefaults+MMEConfiguration.m in Sources */,
+				9C65A28C225D41F2006E3FED /* UIKit+MMEMobileEvents.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1049,30 +1140,31 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				409115371F16BCD200F4250B /* MMECategoryLoader.m in Sources */,
-				40F16C831F02DA9F00DF338D /* MMEDate.m in Sources */,
+				408596631ED086E8003BD29D /* CLLocation+MMEMobileEvents.m in Sources */,
 				AC1B091322137BB000DB56C8 /* CLLocationManager+MMEMobileEvents.m in Sources */,
+				408596611ED086E2003BD29D /* MMEAPIClient.m in Sources */,
+				409115371F16BCD200F4250B /* MMECategoryLoader.m in Sources */,
 				CF93A6592241EDD500BBA199 /* MMECertPin.m in Sources */,
-				408596601ED086DF003BD29D /* MMELocationManager.m in Sources */,
-				408596641ED086EB003BD29D /* MMEUIApplicationWrapper.m in Sources */,
-				4085965F1ED086DC003BD29D /* MMEEventsManager.m in Sources */,
 				4085965C1ED086D3003BD29D /* MMEConstants.m in Sources */,
-				AC61FA5E217A04CC008519F5 /* MMEMetrics.m in Sources */,
-				4036EFC01ED38489009C40BA /* MMEEventLogger.m in Sources */,
-				9CDC34EF2350FB0500852FF0 /* MMEEventLogReportViewController.m in Sources */,
-				4085965E1ED086D9003BD29D /* MMEEvent.m in Sources */,
-				96AB510B21641A6000A261B8 /* MMEUINavigation.m in Sources */,
-				40F133551F200524007B4096 /* NSData+MMEGZIP.m in Sources */,
-				40FB437E1EFAFAE900EC5BC0 /* MMETimerManager.m in Sources */,
+				408596671ED086F4003BD29D /* MMECommonEventData.m in Sources */,
+				40F16C831F02DA9F00DF338D /* MMEDate.m in Sources */,
 				403835041F7AF150004205B9 /* MMEDependencyManager.m in Sources */,
 				AC2C716021124099004179E0 /* MMEDispatchManager.m in Sources */,
-				408596661ED086F1003BD29D /* MMEUniqueIdentifier.m in Sources */,
-				40F16C981F04514100DF338D /* MMEReachability.m in Sources */,
-				408596691ED086FA003BD29D /* MMENSURLSessionWrapper.m in Sources */,
-				408596671ED086F4003BD29D /* MMECommonEventData.m in Sources */,
+				4085965E1ED086D9003BD29D /* MMEEvent.m in Sources */,
+				4036EFC01ED38489009C40BA /* MMEEventLogger.m in Sources */,
+				9CDC34EF2350FB0500852FF0 /* MMEEventLogReportViewController.m in Sources */,
+				4085965F1ED086DC003BD29D /* MMEEventsManager.m in Sources */,
+				408596601ED086DF003BD29D /* MMELocationManager.m in Sources */,
+				AC61FA5E217A04CC008519F5 /* MMEMetrics.m in Sources */,
 				AC86FE1F2169250000D1B89C /* MMEMetricsManager.m in Sources */,
-				408596631ED086E8003BD29D /* CLLocation+MMEMobileEvents.m in Sources */,
-				408596611ED086E2003BD29D /* MMEAPIClient.m in Sources */,
+				408596691ED086FA003BD29D /* MMENSURLSessionWrapper.m in Sources */,
+				40F16C981F04514100DF338D /* MMEReachability.m in Sources */,
+				40FB437E1EFAFAE900EC5BC0 /* MMETimerManager.m in Sources */,
+				408596641ED086EB003BD29D /* MMEUIApplicationWrapper.m in Sources */,
+				96AB510B21641A6000A261B8 /* MMEUINavigation.m in Sources */,
+				408596661ED086F1003BD29D /* MMEUniqueIdentifier.m in Sources */,
+				40F133551F200524007B4096 /* NSData+MMEGZIP.m in Sources */,
+				9CF00044237102B8009A2700 /* NSUserDefaults+MMEConfiguration.m in Sources */,
 				9C65A28D225D41F2006E3FED /* UIKit+MMEMobileEvents.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1115,6 +1207,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		9CF000482371037E009A2700 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9CF000492371037E009A2700 /* MMETestDelegate.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -1144,6 +1244,11 @@
 			isa = PBXTargetDependency;
 			target = 408596521ED084C0003BD29D /* libMapboxMobileEvents */;
 			targetProxy = 9C63226C221377CD00653792 /* PBXContainerItemProxy */;
+		};
+		9CF0006B23710389009A2700 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 408596521ED084C0003BD29D /* libMapboxMobileEvents */;
+			targetProxy = 9CF0006A23710389009A2700 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1555,6 +1660,63 @@
 			};
 			name = Release;
 		};
+		9CF000662371037E009A2700 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_ENTITLEMENTS = MMETestHost/MMETestHost.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = GJZR2MEM28;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "MMETestHost/MMETestHost-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MMETestHost;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		9CF000672371037E009A2700 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_ENTITLEMENTS = MMETestHost/MMETestHost.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = GJZR2MEM28;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "MMETestHost/MMETestHost-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MMETestHost;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1617,6 +1779,15 @@
 			buildConfigurations = (
 				9CDC34EB23502F8700852FF0 /* Debug */,
 				9CDC34EC23502F8700852FF0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9CF000652371037E009A2700 /* Build configuration list for PBXNativeTarget "MMETestHost (Static)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9CF000662371037E009A2700 /* Debug */,
+				9CF000672371037E009A2700 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/MapboxMobileEvents.xcodeproj/xcshareddata/xcschemes/MMECedarTests.xcscheme
+++ b/MapboxMobileEvents.xcodeproj/xcshareddata/xcschemes/MMECedarTests.xcscheme
@@ -52,6 +52,16 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9C65A2652256C110006E3FED"
+            BuildableName = "MMETestHost.app"
+            BlueprintName = "MMETestHost"
+            ReferencedContainer = "container:MapboxMobileEvents.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/MapboxMobileEvents.xcodeproj/xcshareddata/xcschemes/MMETestHost (Static).xcscheme
+++ b/MapboxMobileEvents.xcodeproj/xcshareddata/xcschemes/MMETestHost (Static).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1110"
+   LastUpgradeVersion = "1120"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -10,27 +10,13 @@
             buildForTesting = "YES"
             buildForRunning = "YES"
             buildForProfiling = "YES"
-            buildForArchiving = "NO"
+            buildForArchiving = "YES"
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "404807C11EA186D8008A6D50"
-               BuildableName = "MMEXCTests.xctest"
-               BlueprintName = "MMEXCTests"
-               ReferencedContainer = "container:MapboxMobileEvents.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9C65A2652256C110006E3FED"
-               BuildableName = "MMETestHost.app"
-               BlueprintName = "MMETestHost"
+               BlueprintIdentifier = "9CF000452371037E009A2700"
+               BuildableName = "MMETestHost (Static).app"
+               BlueprintName = "MMETestHost (Static)"
                ReferencedContainer = "container:MapboxMobileEvents.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -40,27 +26,14 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "404807C11EA186D8008A6D50"
-               BuildableName = "MMEXCTests.xctest"
-               BlueprintName = "MMEXCTests"
-               ReferencedContainer = "container:MapboxMobileEvents.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      enableThreadSanitizer = "YES"
-      enableUBSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -71,9 +44,9 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "9C65A2652256C110006E3FED"
-            BuildableName = "MMETestHost.app"
-            BlueprintName = "MMETestHost"
+            BlueprintIdentifier = "9CF000452371037E009A2700"
+            BuildableName = "MMETestHost (Static).app"
+            BlueprintName = "MMETestHost (Static)"
             ReferencedContainer = "container:MapboxMobileEvents.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
@@ -84,15 +57,16 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "404807C11EA186D8008A6D50"
-            BuildableName = "MMEXCTests.xctest"
-            BlueprintName = "MMEXCTests"
+            BlueprintIdentifier = "9CF000452371037E009A2700"
+            BuildableName = "MMETestHost (Static).app"
+            BlueprintName = "MMETestHost (Static)"
             ReferencedContainer = "container:MapboxMobileEvents.xcodeproj">
          </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">


### PR DESCRIPTION
This sorts and synchronizes the target membership lists for the `MapboxMobileEvents.framework` and `libMapboxMobileEvents.a` products