### PR TITLE
Authorization change

### DIFF
--- a/MapboxMobileEvents.xcodeproj/xcshareddata/xcschemes/MMECedarTests.xcscheme
+++ b/MapboxMobileEvents.xcodeproj/xcshareddata/xcschemes/MMECedarTests.xcscheme
@@ -69,15 +69,16 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "9CDC34C223502F8700852FF0"
-            BuildableName = "MMECedarTests.xctest"
-            BlueprintName = "MMECedarTests"
+            BlueprintIdentifier = "9C65A2652256C110006E3FED"
+            BuildableName = "MMETestHost.app"
+            BlueprintName = "MMETestHost"
             ReferencedContainer = "container:MapboxMobileEvents.xcodeproj">
          </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/MapboxMobileEvents.xcodeproj/xcshareddata/xcschemes/MMEXCTests.xcscheme
+++ b/MapboxMobileEvents.xcodeproj/xcshareddata/xcschemes/MMEXCTests.xcscheme
@@ -84,15 +84,16 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "404807C11EA186D8008A6D50"
-            BuildableName = "MMEXCTests.xctest"
-            BlueprintName = "MMEXCTests"
+            BlueprintIdentifier = "9C65A2652256C110006E3FED"
+            BuildableName = "MMETestHost.app"
+            BlueprintName = "MMETestHost"
             ReferencedContainer = "container:MapboxMobileEvents.xcodeproj">
          </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/MapboxMobileEvents/MMEEventsManager.m
+++ b/MapboxMobileEvents/MMEEventsManager.m
@@ -207,7 +207,7 @@ NS_ASSUME_NONNULL_BEGIN
             [self resumeMetricsCollection];
         } else if ((applicationState == UIApplicationStateBackground
                    && NSUserDefaults.mme_configuration.mme_isCollectionEnabledInBackground == NO)
-                   || NSUserDefaults.mme_configuration.mme_isCollectionEnabled == NO)) {
+                   || NSUserDefaults.mme_configuration.mme_isCollectionEnabled == NO) {
             [self pauseMetricsCollection];
         }
     } else if (authStatus == kCLAuthorizationStatusAuthorizedWhenInUse) {

--- a/MapboxMobileEvents/MMEEventsManager.m
+++ b/MapboxMobileEvents/MMEEventsManager.m
@@ -205,7 +205,9 @@ NS_ASSUME_NONNULL_BEGIN
          || (applicationState == UIApplicationStateBackground && NSUserDefaults.mme_configuration.mme_isCollectionEnabledInBackground))
          && self.isPaused) {
             [self resumeMetricsCollection];
-        } else {
+        } else if ((applicationState == UIApplicationStateBackground
+                   && NSUserDefaults.mme_configuration.mme_isCollectionEnabledInBackground == NO)
+                   || NSUserDefaults.mme_configuration.mme_isCollectionEnabled == NO)) {
             [self pauseMetricsCollection];
         }
     } else if (authStatus == kCLAuthorizationStatusAuthorizedWhenInUse) {

--- a/Tests/MMEEventsManagerTests.m
+++ b/Tests/MMEEventsManagerTests.m
@@ -69,11 +69,11 @@
     XCTAssert(self.eventsManager.paused == NO);
 }
 
-- (void)testPausesWithAlwaysAuthAndBackgrounded {
-    self.eventsManager.paused = NO;
+- (void)testUnpausesWithAlwaysAuthAndBackgrounded {
+    self.eventsManager.paused = YES;
     
     [self.eventsManager processAuthorizationStatus:kCLAuthorizationStatusAuthorizedAlways andApplicationState:UIApplicationStateBackground];
-    XCTAssert(self.eventsManager.paused == YES);
+    XCTAssert(self.eventsManager.paused == NO);
 }
 
 - (void)testUnpausesWithAlwaysAuthAndAppActive {


### PR DESCRIPTION
Metrics were not being enabled or disabled properly when switching to the background and `Always` authorization was enabled.

Also, adds executable to test targets for profiling.