### PR TITLE
Log Debug Events

### DIFF
--- a/MapboxMobileEvents/MMEAPIClient.m
+++ b/MapboxMobileEvents/MMEAPIClient.m
@@ -7,6 +7,8 @@
 #import "MMEMetricsManager.h"
 #import "MMEEventsManager.h"
 #import "MMEEventsManager_Private.h"
+#import "MMEEventLogger.h"
+
 #import "NSData+MMEGZIP.h"
 #import "NSUserDefaults+MMEConfiguration.h"
 #import "NSUserDefaults+MMEConfiguration_Private.h"
@@ -299,7 +301,7 @@ int const kMMEMaxRequestCount = 1000;
             [request setHTTPBody:jsonData];
         }
     } else if (jsonError) {
-        [MMEEventsManager.sharedManager pushEvent:[MMEEvent debugEventWithError:jsonError]];
+        [MMEEventLogger.sharedLogger logEvent:[MMEEvent debugEventWithError:jsonError]];
 
         return nil;
     }
@@ -334,7 +336,7 @@ int const kMMEMaxRequestCount = 1000;
         [httpBody appendData:jsonData];
         [httpBody appendData:[[NSString stringWithFormat:@"\r\n\r\n"] dataUsingEncoding:NSUTF8StringEncoding]];
     } else if (jsonError) {
-        [MMEEventsManager.sharedManager pushEvent:[MMEEvent debugEventWithError:jsonError]];
+        [MMEEventLogger.sharedLogger logEvent:[MMEEvent debugEventWithError:jsonError]];
     }
 
     for (NSString *path in filePaths) { // add a file part for each

--- a/MapboxMobileEvents/MMEEventsManager.m
+++ b/MapboxMobileEvents/MMEEventsManager.m
@@ -270,7 +270,7 @@ NS_ASSUME_NONNULL_BEGIN
                 __strong __typeof__(weakSelf) strongSelf = weakSelf;
 
                 if (error) {
-                    [MMEEventsManager.sharedManager pushEvent:[MMEEvent debugEventWithError:error]];
+                    [MMEEventLogger.sharedLogger logEvent:[MMEEvent debugEventWithError:error]];
                 } else {
                     [strongSelf pushDebugEventWithAttributes:@{
                         MMEDebugEventType: MMEDebugEventTypePost,
@@ -405,7 +405,7 @@ NS_ASSUME_NONNULL_BEGIN
             __strong __typeof__(weakSelf) strongSelf = weakSelf;
 
             if (error) {
-                [strongSelf pushEvent:[MMEEvent debugEventWithError:error]];
+                [MMEEventLogger.sharedLogger logEvent:[MMEEvent debugEventWithError:error]];
                 return;
             }
 
@@ -529,7 +529,7 @@ NS_ASSUME_NONNULL_BEGIN
             [self pushEvent:errorEvent];
         }
         else {
-            [self pushEvent:[MMEEvent debugEventWithError:createError]];
+            [MMEEventLogger.sharedLogger logEvent:[MMEEvent debugEventWithError:createError]];
         }
     }
     @catch(NSException *except) {

--- a/MapboxMobileEvents/MMEMetricsManager.m
+++ b/MapboxMobileEvents/MMEMetricsManager.m
@@ -333,7 +333,7 @@
         if (jsonData) {
             jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
         } else if (jsonError) {
-            [[MMEEventsManager sharedManager] pushEvent:[MMEEvent debugEventWithError:jsonError]];
+            [MMEEventLogger.sharedLogger logEvent:[MMEEvent debugEventWithError:jsonError]];
         }
         return jsonString;
     }

--- a/MapboxMobileEvents/MMENSURLSessionWrapper.m
+++ b/MapboxMobileEvents/MMENSURLSessionWrapper.m
@@ -2,6 +2,7 @@
 #import "MMEEventsManager.h"
 #import "MMECertPin.h"
 #import "MMEEvent.h"
+#import "MMEEventLogger.h"
 
 #pragma mark -
 
@@ -64,7 +65,7 @@
 -(void)URLSession:(NSURLSession *)session didBecomeInvalidWithError:(NSError *)error {
     if (error) { // only recreate the session if the error was non-nil
         self.session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration] delegate:self delegateQueue:nil];
-        [[MMEEventsManager sharedManager] pushEvent:[MMEEvent debugEventWithError:error]];
+        [MMEEventLogger.sharedLogger logEvent:[MMEEvent debugEventWithError:error]];
     }
     else { // release the session object
         self.session = nil;

--- a/Tests/MMEEventsManagerTests.mm
+++ b/Tests/MMEEventsManagerTests.mm
@@ -65,7 +65,7 @@ describe(@"MMEventsManager.sharedManager", ^{
     MMEEventsManager *shared = MMEEventsManager.sharedManager;
     MMEEventsManager *allocated = [MMEEventsManager.alloc init];
 
-    it(@"", ^{
+    it(@"should equal the allocated manager", ^{
         shared should equal(allocated);
     });
 });


### PR DESCRIPTION
`MMEEventsManager.sharedManager` was not allowing for the events to be queued in the tests.

`debugEvent`s shouldn't be pushed, only logged.