### PR TITLE
Fix trailing semicolon warning

### DIFF
--- a/MapboxMobileEvents/Categories/UIKit+MMEMobileEvents.m
+++ b/MapboxMobileEvents/Categories/UIKit+MMEMobileEvents.m
@@ -2,7 +2,7 @@
 
 @implementation NSObject (MMEMobileEvents)
 
-void mme_linkUIKitCategories(){};
+void mme_linkUIKitCategories(){}
 
 @end
 


### PR DESCRIPTION
```
MapboxMobileEvents/UIKit+MMEMobileEvents.m:5:33: error: extra ';' outside of a function [-Werror,-Wextra-semi]
void mme_linkUIKitCategories(){};
                                ^
```