### PR TITLE
iOS (App Extension): Friendly Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ fastlane/test_output
 
 test_output/
 docs/
+.DS_Store

--- a/MapboxMobileEvents.xcodeproj/project.pbxproj
+++ b/MapboxMobileEvents.xcodeproj/project.pbxproj
@@ -203,6 +203,9 @@
 		CF93A6582241EDD500BBA199 /* MMECertPin.m in Sources */ = {isa = PBXBuildFile; fileRef = CF93A6562241EDD500BBA199 /* MMECertPin.m */; };
 		CF93A6592241EDD500BBA199 /* MMECertPin.m in Sources */ = {isa = PBXBuildFile; fileRef = CF93A6562241EDD500BBA199 /* MMECertPin.m */; platformFilter = ios; };
 		CF93A65B2241EDD500BBA199 /* MMECertPin.h in Headers */ = {isa = PBXBuildFile; fileRef = CF93A6572241EDD500BBA199 /* MMECertPin.h */; };
+		F4684FF42432A1610079B389 /* NSBundle+MMEMobileEvents.h in Headers */ = {isa = PBXBuildFile; fileRef = F4684FF22432A1610079B389 /* NSBundle+MMEMobileEvents.h */; };
+		F4684FF52432A1610079B389 /* NSBundle+MMEMobileEvents.m in Sources */ = {isa = PBXBuildFile; fileRef = F4684FF32432A1610079B389 /* NSBundle+MMEMobileEvents.m */; };
+		F4684FF62432A2770079B389 /* NSBundle+MMEMobileEvents.m in Sources */ = {isa = PBXBuildFile; fileRef = F4684FF32432A1610079B389 /* NSBundle+MMEMobileEvents.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -454,6 +457,8 @@
 		CF93A6562241EDD500BBA199 /* MMECertPin.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MMECertPin.m; sourceTree = "<group>"; };
 		CF93A6572241EDD500BBA199 /* MMECertPin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MMECertPin.h; sourceTree = "<group>"; };
 		CF93A66222488A4500BBA199 /* MMECertPinTests.m */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; path = MMECertPinTests.m; sourceTree = "<group>"; };
+		F4684FF22432A1610079B389 /* NSBundle+MMEMobileEvents.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSBundle+MMEMobileEvents.h"; sourceTree = "<group>"; };
+		F4684FF32432A1610079B389 /* NSBundle+MMEMobileEvents.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSBundle+MMEMobileEvents.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -617,6 +622,8 @@
 				AC1B091022137BB000DB56C8 /* CLLocationManager+MMEMobileEvents.m */,
 				409115331F16BCD200F4250B /* MMECategoryLoader.h */,
 				409115341F16BCD200F4250B /* MMECategoryLoader.m */,
+				F4684FF22432A1610079B389 /* NSBundle+MMEMobileEvents.h */,
+				F4684FF32432A1610079B389 /* NSBundle+MMEMobileEvents.m */,
 				40F133521F20051E007B4096 /* NSData+MMEGZIP.h */,
 				40F133511F20051E007B4096 /* NSData+MMEGZIP.m */,
 				9CF0003E2370D674009A2700 /* NSString+MMEVersions.h */,
@@ -801,6 +808,7 @@
 			files = (
 				9CDC34B8234FD35800852FF0 /* NSUserDefaults+MMEConfiguration.h in Headers */,
 				404807CA1EA186D8008A6D50 /* MapboxMobileEvents.h in Headers */,
+				F4684FF42432A1610079B389 /* NSBundle+MMEMobileEvents.h in Headers */,
 				40AE58561EA932DB0046B437 /* MMEConstants.h in Headers */,
 				40AE586D1EA95EDD0046B437 /* MMEEvent.h in Headers */,
 				40C9E27B1EA542BC00744FE7 /* MMEEventsManager.h in Headers */,
@@ -1138,6 +1146,7 @@
 				40F16C971F04514100DF338D /* MMEReachability.m in Sources */,
 				40FB437D1EFAFAE900EC5BC0 /* MMETimerManager.m in Sources */,
 				40AE58441EA6C86C0046B437 /* MMEUIApplicationWrapper.m in Sources */,
+				F4684FF52432A1610079B389 /* NSBundle+MMEMobileEvents.m in Sources */,
 				40AE585B1EA9373F0046B437 /* MMEUniqueIdentifier.m in Sources */,
 				40F133531F20051E007B4096 /* NSData+MMEGZIP.m in Sources */,
 				9C65A28C225D41F2006E3FED /* UIKit+MMEMobileEvents.m in Sources */,
@@ -1179,6 +1188,7 @@
 			files = (
 				AC1B091322137BB000DB56C8 /* CLLocationManager+MMEMobileEvents.m in Sources */,
 				409115371F16BCD200F4250B /* MMECategoryLoader.m in Sources */,
+				F4684FF62432A2770079B389 /* NSBundle+MMEMobileEvents.m in Sources */,
 				CF93A6592241EDD500BBA199 /* MMECertPin.m in Sources */,
 				4085965C1ED086D3003BD29D /* MMEConstants.m in Sources */,
 				40F16C831F02DA9F00DF338D /* MMEDate.m in Sources */,

--- a/MapboxMobileEvents/Categories/NSBundle+MMEMobileEvents.h
+++ b/MapboxMobileEvents/Categories/NSBundle+MMEMobileEvents.h
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NSBundle (MMEMobileEvents)
+
++ (BOOL)mme_isExtension;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MapboxMobileEvents/Categories/NSBundle+MMEMobileEvents.m
+++ b/MapboxMobileEvents/Categories/NSBundle+MMEMobileEvents.m
@@ -1,0 +1,9 @@
+#import "NSBundle+MMEMobileEvents.h"
+
+@implementation NSBundle (MMEMobileEvents)
+
++ (BOOL)mme_isExtension {
+    return [NSBundle.mainBundle.bundleURL.pathExtension isEqualToString:@"appex"];
+}
+
+@end

--- a/MapboxMobileEvents/Categories/UIKit+MMEMobileEvents.h
+++ b/MapboxMobileEvents/Categories/UIKit+MMEMobileEvents.h
@@ -27,4 +27,10 @@ void mme_linkUIKitCategories();
 
 @end
 
+@interface NSExtensionContext (MMEMobileEvents)
+
++ (NSInteger)mme_contentSizeScale;
+
+@end
+
 NS_ASSUME_NONNULL_END

--- a/MapboxMobileEvents/Categories/UIKit+MMEMobileEvents.m
+++ b/MapboxMobileEvents/Categories/UIKit+MMEMobileEvents.m
@@ -82,3 +82,46 @@ void mme_linkUIKitCategories(){}
 }
 
 @end
+
+@implementation NSExtensionContext (MMEMobileEvents)
+
++ (NSInteger)mme_contentSizeScale {
+
+    NSInteger result = -9999;
+
+    if (@available(iOS 10, *)) {
+        NSString *sc = UIScreen.mainScreen.traitCollection.preferredContentSizeCategory;
+
+        if ([sc isEqualToString:UIContentSizeCategoryExtraSmall]) {
+            result = -3;
+        } else if ([sc isEqualToString:UIContentSizeCategorySmall]) {
+            result = -2;
+        } else if ([sc isEqualToString:UIContentSizeCategoryMedium]) {
+            result = -1;
+        } else if ([sc isEqualToString:UIContentSizeCategoryLarge]) {
+            result = 0;
+        } else if ([sc isEqualToString:UIContentSizeCategoryExtraLarge]) {
+            result = 1;
+        } else if ([sc isEqualToString:UIContentSizeCategoryExtraExtraLarge]) {
+            result = 2;
+        } else if ([sc isEqualToString:UIContentSizeCategoryExtraExtraExtraLarge]) {
+            result = 3;
+        } else if ([sc isEqualToString:UIContentSizeCategoryAccessibilityMedium]) {
+            result = -11;
+        } else if ([sc isEqualToString:UIContentSizeCategoryAccessibilityLarge]) {
+            result = 10;
+        } else if ([sc isEqualToString:UIContentSizeCategoryAccessibilityExtraLarge]) {
+            result = 11;
+        } else if ([sc isEqualToString:UIContentSizeCategoryAccessibilityExtraExtraLarge]) {
+            result = 12;
+        } else if ([sc isEqualToString:UIContentSizeCategoryAccessibilityExtraExtraExtraLarge]) {
+            result = 13;
+        }
+    } else {
+        // No-Op
+    }
+
+    return result;
+}
+
+@end

--- a/MapboxMobileEvents/MMECommonEventData.h
+++ b/MapboxMobileEvents/MMECommonEventData.h
@@ -5,6 +5,7 @@ extern NSString * const MMEApplicationStateForeground;
 extern NSString * const MMEApplicationStateBackground;
 extern NSString * const MMEApplicationStateInactive;
 extern NSString * const MMEApplicationStateUnknown;
+extern NSString * const MMEApplicationStateExtension;
 
 @interface MMECommonEventData : NSObject
 

--- a/MapboxMobileEvents/MMECommonEventData.m
+++ b/MapboxMobileEvents/MMECommonEventData.m
@@ -3,6 +3,7 @@
 
 #if TARGET_OS_IOS || TARGET_OS_TVOS
 #import <UIKit/UIKit.h>
+#import "NSBundle+MMEMobileEvents.h"
 #endif
 #include <sys/sysctl.h>
 
@@ -71,16 +72,22 @@ NSString * const MMEApplicationStateUnknown = @"Unknown";
 
 + (NSString *)applicationState {
 #if TARGET_OS_IOS || TARGET_OS_TVOS
-    switch (UIApplication.sharedApplication.applicationState) {
-        case UIApplicationStateActive:
-            return MMEApplicationStateForeground;
-        case UIApplicationStateInactive:
-            return MMEApplicationStateInactive;
-        case UIApplicationStateBackground:
-            return MMEApplicationStateBackground;
-        default:
-            return MMEApplicationStateUnknown;
+
+    if (NSBundle.mme_isExtension) {
+        return MMEApplicationStateUnknown;
+    } else {
+        switch (UIApplication.sharedApplication.applicationState) {
+            case UIApplicationStateActive:
+                return MMEApplicationStateForeground;
+            case UIApplicationStateInactive:
+                return MMEApplicationStateInactive;
+            case UIApplicationStateBackground:
+                return MMEApplicationStateBackground;
+            default:
+                return MMEApplicationStateUnknown;
+        }
     }
+
 #else
     return MMEApplicationStateUnknown;
 #endif

--- a/MapboxMobileEvents/MMECommonEventData.m
+++ b/MapboxMobileEvents/MMECommonEventData.m
@@ -11,6 +11,7 @@ NSString * const MMEApplicationStateForeground = @"Foreground";
 NSString * const MMEApplicationStateBackground = @"Background";
 NSString * const MMEApplicationStateInactive = @"Inactive";
 NSString * const MMEApplicationStateUnknown = @"Unknown";
+NSString * const MMEApplicationStateExtension = @"Extension";
 
 @implementation MMECommonEventData
 
@@ -74,7 +75,7 @@ NSString * const MMEApplicationStateUnknown = @"Unknown";
 #if TARGET_OS_IOS || TARGET_OS_TVOS
 
     if (NSBundle.mme_isExtension) {
-        return MMEApplicationStateUnknown;
+        return MMEApplicationStateExtension;
     } else {
         switch (UIApplication.sharedApplication.applicationState) {
             case UIApplicationStateActive:

--- a/MapboxMobileEvents/MMEDate.m
+++ b/MapboxMobileEvents/MMEDate.m
@@ -55,6 +55,8 @@ static NSTimeInterval _timeOffsetFromServer = 0.0; // TODO maintain a list of MM
     if (!_httpDateFormatter) {
         _httpDateFormatter = [[NSDateFormatter alloc] init];
         [_httpDateFormatter setDateFormat:@"E, d MMM yyyy HH:mm:ss Z"];
+        [_httpDateFormatter setTimeZone:[NSTimeZone timeZoneWithName:@"UTC"]];
+
     }
 
     return _httpDateFormatter;

--- a/MapboxMobileEvents/MMEEvent.m
+++ b/MapboxMobileEvents/MMEEvent.m
@@ -10,6 +10,7 @@
 #import "NSUserDefaults+MMEConfiguration.h"
 #if TARGET_OS_IOS || TARGET_OS_TVOS
 #import "UIKit+MMEMobileEvents.h"
+#import "NSBundle+MMEMobileEvents.h"
 #endif
 
 
@@ -231,7 +232,12 @@
     eventAttributes[MMEEventKeyOperatingSystem] = commonEventData.osVersion;
     eventAttributes[MMEEventKeyResolution] = @(commonEventData.scale);
 #if TARGET_OS_IOS || TARGET_OS_TVOS
-    eventAttributes[MMEEventKeyAccessibilityFontScale] = @(UIApplication.sharedApplication.mme_contentSizeScale);
+
+    if (NSBundle.mme_isExtension) {
+        eventAttributes[MMEEventKeyAccessibilityFontScale] = @(NSExtensionContext.mme_contentSizeScale);
+    } else {
+        eventAttributes[MMEEventKeyAccessibilityFontScale] = @(UIApplication.sharedApplication.mme_contentSizeScale);
+    }
     eventAttributes[MMEEventKeyOrientation] = UIDevice.currentDevice.mme_deviceOrientation;
 #endif
     eventAttributes[MMEEventKeyWifi] = @(MMEReachability.reachabilityForLocalWiFi.isReachableViaWiFi);

--- a/Tests/MMEDateTests.m
+++ b/Tests/MMEDateTests.m
@@ -15,8 +15,7 @@
 - (void)testHTTPDateFormatter {
     NSDate *date = [NSDate dateWithTimeIntervalSince1970:214123];
     NSString *dateString = [MMEDate.HTTPDateFormatter stringFromDate:date];
-    
-    XCTAssert([dateString isEqualToString:@"Sat, 3 Jan 1970 03:28:43 -0800"]);
+    XCTAssert([dateString isEqualToString:@"Sat, 3 Jan 1970 11:28:43 +0000"], @"%@", dateString);
 }
 
 - (void)testNSSecureCoding {


### PR DESCRIPTION
| Obligatory Gif |
| - |
| ![tenor](https://user-images.githubusercontent.com/5083390/77969800-78c89800-729f-11ea-9671-df89b0c04080.gif) |
| Extension |


## 🔧  Issue:
https://github.com/mapbox/mapbox-events-ios/issues/47#event-3180214494

## 🥅 Goal:
Play friendly with usage inside of an extension

## 📚  Context:
When using this module inside of an extension, developers will see errors in console:
'sharedApplication' is unavailable: not available on iOS (App Extension) - Use view controller based solutions where appropriate instead.

## 🗺 Approach:
1. Leverage view controller based solutions where appropriate (Available in iOS10 +
2. Inspect bundle to determine if if an extension or not to determine whether or not to access model information with Application or ExtensionContext

## 👷 Changes:
+ Add NSBundle Extensin to inspect whether in an Extension
+ Add NSExtensionContext to extract contentSizeScale from view controller based solution.
+ Inspect Bundle/Extension to construct Scale/State values

## 🔨 Unrelated Change:
+ Included DS_Store so it doesn’t clutter git diff