### PR TITLE
Extension Example: Today Widget

### DIFF
--- a/MapboxMobileEvents.xcodeproj/project.pbxproj
+++ b/MapboxMobileEvents.xcodeproj/project.pbxproj
@@ -203,6 +203,10 @@
 		CF93A6582241EDD500BBA199 /* MMECertPin.m in Sources */ = {isa = PBXBuildFile; fileRef = CF93A6562241EDD500BBA199 /* MMECertPin.m */; };
 		CF93A6592241EDD500BBA199 /* MMECertPin.m in Sources */ = {isa = PBXBuildFile; fileRef = CF93A6562241EDD500BBA199 /* MMECertPin.m */; platformFilter = ios; };
 		CF93A65B2241EDD500BBA199 /* MMECertPin.h in Headers */ = {isa = PBXBuildFile; fileRef = CF93A6572241EDD500BBA199 /* MMECertPin.h */; };
+		F4D48A8A248EEC96004A7517 /* NotificationCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4D48A89248EEC96004A7517 /* NotificationCenter.framework */; };
+		F4D48A8E248EEC96004A7517 /* TodayViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F4D48A8D248EEC96004A7517 /* TodayViewController.m */; };
+		F4D48A91248EEC96004A7517 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F4D48A8F248EEC96004A7517 /* MainInterface.storyboard */; };
+		F4D48A95248EEC96004A7517 /* MapboxMobileEventsTodayExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = F4D48A88248EEC96004A7517 /* MapboxMobileEventsTodayExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -255,6 +259,20 @@
 			remoteGlobalIDString = 404807B81EA186D8008A6D50;
 			remoteInfo = MapboxMobileEvents;
 		};
+		F4D48A93248EEC96004A7517 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 404807B01EA186D8008A6D50 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F4D48A87248EEC96004A7517;
+			remoteInfo = MapboxMobileEventsTodayExtension;
+		};
+		F4D48A9B248EF017004A7517 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 404807B01EA186D8008A6D50 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 404807B81EA186D8008A6D50;
+			remoteInfo = MapboxMobileEvents;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -294,6 +312,17 @@
 				9CF000642371037E009A2700 /* Cedar.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F4D48A96248EEC96004A7517 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				F4D48A95248EEC96004A7517 /* MapboxMobileEventsTodayExtension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -454,6 +483,12 @@
 		CF93A6562241EDD500BBA199 /* MMECertPin.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MMECertPin.m; sourceTree = "<group>"; };
 		CF93A6572241EDD500BBA199 /* MMECertPin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MMECertPin.h; sourceTree = "<group>"; };
 		CF93A66222488A4500BBA199 /* MMECertPinTests.m */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; path = MMECertPinTests.m; sourceTree = "<group>"; };
+		F4D48A88248EEC96004A7517 /* MapboxMobileEventsTodayExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = MapboxMobileEventsTodayExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		F4D48A89248EEC96004A7517 /* NotificationCenter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NotificationCenter.framework; path = System/Library/Frameworks/NotificationCenter.framework; sourceTree = SDKROOT; };
+		F4D48A8C248EEC96004A7517 /* TodayViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TodayViewController.h; sourceTree = "<group>"; };
+		F4D48A8D248EEC96004A7517 /* TodayViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TodayViewController.m; sourceTree = "<group>"; };
+		F4D48A90248EEC96004A7517 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
+		F4D48A92248EEC96004A7517 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -508,6 +543,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F4D48A85248EEC96004A7517 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F4D48A8A248EEC96004A7517 /* NotificationCenter.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -517,6 +560,7 @@
 				9C794C85235505340027B9D4 /* XCTest.framework */,
 				40A7F9911F79A743002B931F /* Cedar.framework */,
 				4032F47D1F1FEDC6001C1FBD /* libz.tbd */,
+				F4D48A89248EEC96004A7517 /* NotificationCenter.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -529,6 +573,7 @@
 				404807BB1EA186D8008A6D50 /* MapboxMobileEvents */,
 				404807C61EA186D8008A6D50 /* Tests */,
 				9C65A2672256C110006E3FED /* MMETestHost */,
+				F4D48A8B248EEC96004A7517 /* MapboxMobileEventsTodayExtension */,
 				4032F47C1F1FEDC6001C1FBD /* Frameworks */,
 				9C6D9882221F37A200679292 /* Packaging */,
 				404807BA1EA186D8008A6D50 /* Products */,
@@ -545,6 +590,7 @@
 				9C65A2662256C110006E3FED /* MMETestHost.app */,
 				9CDC34ED23502F8700852FF0 /* MMECedarTests.xctest */,
 				9CF000682371037E009A2700 /* MMETestHost (Static).app */,
+				F4D48A88248EEC96004A7517 /* MapboxMobileEventsTodayExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -792,6 +838,17 @@
 			name = XCTest;
 			sourceTree = "<group>";
 		};
+		F4D48A8B248EEC96004A7517 /* MapboxMobileEventsTodayExtension */ = {
+			isa = PBXGroup;
+			children = (
+				F4D48A8C248EEC96004A7517 /* TodayViewController.h */,
+				F4D48A8D248EEC96004A7517 /* TodayViewController.m */,
+				F4D48A8F248EEC96004A7517 /* MainInterface.storyboard */,
+				F4D48A92248EEC96004A7517 /* Info.plist */,
+			);
+			path = MapboxMobileEventsTodayExtension;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -898,11 +955,13 @@
 				9C65A2632256C110006E3FED /* Frameworks */,
 				9C65A2642256C110006E3FED /* Resources */,
 				9C65A2832256C1CF006E3FED /* Embed Frameworks */,
+				F4D48A96248EEC96004A7517 /* Embed App Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				9C16239123577E66005DB983 /* PBXTargetDependency */,
+				F4D48A94248EEC96004A7517 /* PBXTargetDependency */,
 			);
 			name = MMETestHost;
 			productName = MMETestHost;
@@ -947,6 +1006,24 @@
 			productReference = 9CF000682371037E009A2700 /* MMETestHost (Static).app */;
 			productType = "com.apple.product-type.application";
 		};
+		F4D48A87248EEC96004A7517 /* MapboxMobileEventsTodayExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F4D48A9A248EEC96004A7517 /* Build configuration list for PBXNativeTarget "MapboxMobileEventsTodayExtension" */;
+			buildPhases = (
+				F4D48A84248EEC96004A7517 /* Sources */,
+				F4D48A85248EEC96004A7517 /* Frameworks */,
+				F4D48A86248EEC96004A7517 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				F4D48A9C248EF017004A7517 /* PBXTargetDependency */,
+			);
+			name = MapboxMobileEventsTodayExtension;
+			productName = MapboxMobileEventsTodayExtension;
+			productReference = F4D48A88248EEC96004A7517 /* MapboxMobileEventsTodayExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -989,6 +1066,9 @@
 						DevelopmentTeam = GJZR2MEM28;
 						TestTargetID = 9C65A2652256C110006E3FED;
 					};
+					F4D48A87248EEC96004A7517 = {
+						CreatedOnToolsVersion = 11.5;
+					};
 				};
 			};
 			buildConfigurationList = 404807B31EA186D8008A6D50 /* Build configuration list for PBXProject "MapboxMobileEvents" */;
@@ -1011,6 +1091,7 @@
 				9CDC34C223502F8700852FF0 /* MMECedarTests */,
 				9C65A2652256C110006E3FED /* MMETestHost */,
 				9CF000452371037E009A2700 /* MMETestHost (Static) */,
+				F4D48A87248EEC96004A7517 /* MapboxMobileEventsTodayExtension */,
 			);
 		};
 /* End PBXProject section */
@@ -1088,6 +1169,14 @@
 				9CF0005F2371037E009A2700 /* config-number-tag.json in Resources */,
 				9CF000602371037E009A2700 /* config-type1-tto.json in Resources */,
 				9CF000612371037E009A2700 /* config-100m-gfo.json in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F4D48A86248EEC96004A7517 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F4D48A91248EEC96004A7517 /* MainInterface.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1245,6 +1334,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F4D48A84248EEC96004A7517 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F4D48A8E248EEC96004A7517 /* TodayViewController.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -1286,6 +1383,16 @@
 			target = 404807B81EA186D8008A6D50 /* MapboxMobileEvents */;
 			targetProxy = AC881B1423FDEDBF00E614B7 /* PBXContainerItemProxy */;
 		};
+		F4D48A94248EEC96004A7517 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F4D48A87248EEC96004A7517 /* MapboxMobileEventsTodayExtension */;
+			targetProxy = F4D48A93248EEC96004A7517 /* PBXContainerItemProxy */;
+		};
+		F4D48A9C248EF017004A7517 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 404807B81EA186D8008A6D50 /* MapboxMobileEvents */;
+			targetProxy = F4D48A9B248EF017004A7517 /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
@@ -1303,6 +1410,14 @@
 				9C65A2742256C112006E3FED /* Base */,
 			);
 			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+		F4D48A8F248EEC96004A7517 /* MainInterface.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				F4D48A90248EEC96004A7517 /* Base */,
+			);
+			name = MainInterface.storyboard;
 			sourceTree = "<group>";
 		};
 /* End PBXVariantGroup section */
@@ -1973,6 +2088,79 @@
 			};
 			name = RelWithDebInfo;
 		};
+		F4D48A97248EEC96004A7517 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = GJZR2MEM28;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = MapboxMobileEventsTodayExtension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MMETestHost.MapboxMobileEventsTodayExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		F4D48A98248EEC96004A7517 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = GJZR2MEM28;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = MapboxMobileEventsTodayExtension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MMETestHost.MapboxMobileEventsTodayExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		F4D48A99248EEC96004A7517 /* RelWithDebInfo */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = GJZR2MEM28;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = MapboxMobileEventsTodayExtension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MMETestHost.MapboxMobileEventsTodayExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = RelWithDebInfo;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -2052,6 +2240,16 @@
 				9CF000662371037E009A2700 /* Debug */,
 				9CF000672371037E009A2700 /* Release */,
 				CAB36C372374A1BA00592F74 /* RelWithDebInfo */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F4D48A9A248EEC96004A7517 /* Build configuration list for PBXNativeTarget "MapboxMobileEventsTodayExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F4D48A97248EEC96004A7517 /* Debug */,
+				F4D48A98248EEC96004A7517 /* Release */,
+				F4D48A99248EEC96004A7517 /* RelWithDebInfo */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/MapboxMobileEvents.xcodeproj/xcshareddata/xcschemes/MapboxMobileEventsTodayExtension.xcscheme
+++ b/MapboxMobileEvents.xcodeproj/xcshareddata/xcschemes/MapboxMobileEventsTodayExtension.xcscheme
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1150"
+   wasCreatedForAppExtension = "YES"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F4D48A87248EEC96004A7517"
+               BuildableName = "MapboxMobileEventsTodayExtension.appex"
+               BlueprintName = "MapboxMobileEventsTodayExtension"
+               ReferencedContainer = "container:MapboxMobileEvents.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9C65A2652256C110006E3FED"
+               BuildableName = "MMETestHost.app"
+               BlueprintName = "MMETestHost"
+               ReferencedContainer = "container:MapboxMobileEvents.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      askForAppToLaunch = "Yes"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.springboard">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F4D48A87248EEC96004A7517"
+            BuildableName = "MapboxMobileEventsTodayExtension.appex"
+            BlueprintName = "MapboxMobileEventsTodayExtension"
+            ReferencedContainer = "container:MapboxMobileEvents.xcodeproj">
+         </BuildableReference>
+      </RemoteRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9C65A2652256C110006E3FED"
+            BuildableName = "MMETestHost.app"
+            BlueprintName = "MMETestHost"
+            ReferencedContainer = "container:MapboxMobileEvents.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <LocationScenarioReference
+         identifier = "San Francisco, CA, USA"
+         referenceType = "1">
+      </LocationScenarioReference>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9C65A2652256C110006E3FED"
+            BuildableName = "MMETestHost.app"
+            BlueprintName = "MMETestHost"
+            ReferencedContainer = "container:MapboxMobileEvents.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/MapboxMobileEventsTodayExtension/Base.lproj/MainInterface.storyboard
+++ b/MapboxMobileEventsTodayExtension/Base.lproj/MainInterface.storyboard
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="M4Y-Lb-cyx">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Today View Controller-->
+        <scene sceneID="cwh-vc-ff4">
+            <objects>
+                <viewController id="M4Y-Lb-cyx" customClass="TodayViewController" customModuleProvider="" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" simulatedAppContext="notificationCenter" id="S3S-Oj-5AN">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="37"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="top" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hello World" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="280" translatesAutoresizingMaskIntoConstraints="NO" id="GcN-lo-r42">
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" xcode11CocoaTouchSystemColor="labelColor" cocoaTouchSystemColor="lightTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="ssy-KU-ocm" firstAttribute="bottom" secondItem="GcN-lo-r42" secondAttribute="bottom" constant="20" symbolic="YES" id="0Q0-KW-PJ6"/>
+                            <constraint firstItem="GcN-lo-r42" firstAttribute="leading" secondItem="ssy-KU-ocm" secondAttribute="leading" constant="20" symbolic="YES" id="6Vq-gs-PHe"/>
+                            <constraint firstItem="ssy-KU-ocm" firstAttribute="trailing" secondItem="GcN-lo-r42" secondAttribute="trailing" constant="20" symbolic="YES" id="L8K-9R-egU"/>
+                            <constraint firstItem="GcN-lo-r42" firstAttribute="top" secondItem="ssy-KU-ocm" secondAttribute="top" constant="20" symbolic="YES" id="mYS-Cv-VNx"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="ssy-KU-ocm"/>
+                    </view>
+                    <extendedEdge key="edgesForExtendedLayout"/>
+                    <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+                    <size key="freeformSize" width="320" height="37"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="vXp-U4-Rya" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/MapboxMobileEventsTodayExtension/Info.plist
+++ b/MapboxMobileEventsTodayExtension/Info.plist
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>MapboxMobileEventsTodayExtension</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionMainStoryboard</key>
+		<string>MainInterface</string>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widget-extension</string>
+	</dict>
+	<key>MMECollectionEnabledInSimulator</key>
+	<true/>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Always and When in Use Description</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>Always Usage Descriptoin</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>When in Use Description</string>
+</dict>
+</plist>

--- a/MapboxMobileEventsTodayExtension/TodayViewController.h
+++ b/MapboxMobileEventsTodayExtension/TodayViewController.h
@@ -1,0 +1,13 @@
+//
+//  TodayViewController.h
+//  MapboxMobileEventsTodayExtension
+//
+//  Created by Dane Miluski on 6/8/20.
+//  Copyright © 2020 Mapbox. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface TodayViewController : UIViewController
+
+@end

--- a/MapboxMobileEventsTodayExtension/TodayViewController.m
+++ b/MapboxMobileEventsTodayExtension/TodayViewController.m
@@ -1,0 +1,71 @@
+//
+//  TodayViewController.m
+//  MapboxMobileEventsTodayExtension
+//
+//  Created by Dane Miluski on 6/8/20.
+//  Copyright © 2020 Mapbox. All rights reserved.
+//
+
+#import "TodayViewController.h"
+#import <NotificationCenter/NotificationCenter.h>
+#import <MapboxMobileEvents/MapboxMobileEvents.h>
+#import "MMEUIApplicationWrapper.h"
+#import <CoreLocation/CoreLocation.h>
+#import <MapKit/MapKit.h>
+
+@interface TodayViewController () <NCWidgetProviding, CLLocationManagerDelegate>
+@property (nonatomic, strong) CLLocationManager *locationManager;
+@property (nonatomic, strong) MKMapView *mapView;
+@end
+
+@implementation TodayViewController
+
+- (instancetype)initWithCoder:(NSCoder *)coder {
+    if (self = [super initWithCoder:coder]) {
+        self.locationManager = [[CLLocationManager alloc] init];
+        self.mapView = [[MKMapView alloc] init];
+        self.mapView.translatesAutoresizingMaskIntoConstraints = false;
+    }
+    return self;
+}
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do any additional setup after loading the view.
+
+    [MMEEventsManager.sharedManager initializeWithAccessToken:@"foo" userAgentBase:@"bar" hostSDKVersion:@"host"];
+    self.locationManager.delegate = self;
+    [self.locationManager requestWhenInUseAuthorization];
+
+    // Include MKMapView as demonstration for including map in extension
+    [self.view addSubview:self.mapView];
+    [NSLayoutConstraint activateConstraints:@[
+        [self.mapView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+        [self.mapView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+        [self.mapView.topAnchor constraintEqualToAnchor:self.view.topAnchor],
+        [self.mapView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor],
+    ]];
+
+    [MMEEventsManager.sharedManager sendTurnstileEvent];
+    [MMEEventsManager.sharedManager flush];
+}
+
+- (void)widgetPerformUpdateWithCompletionHandler:(void (^)(NCUpdateResult))completionHandler {
+    // Perform any setup necessary in order to update the view.
+    
+    // If an error is encountered, use NCUpdateResultFailed
+    // If there's no update required, use NCUpdateResultNoData
+    // If there's an update, use NCUpdateResultNewData
+
+    // For Demo Purposes, assume new data
+    completionHandler(NCUpdateResultNewData);
+}
+
+- (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {
+    [manager startUpdatingLocation];
+}
+
+- (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(nonnull NSArray<CLLocation *> *)locations {
+    NSLog(@"Location updated: %@",locations);
+}
+
+@end


### PR DESCRIPTION
## 🥅  Goal:
Show that MapboxMobileEvents SDK is able to be built/run in an extension.

## 🗺️  Steps:
1. Create Extension which depended on Events SDK
2. Include required permission keys in info.plist
3. Start SDK with mock values
4. Agree to permissions, and also set simulator to use bicycle ride simulation.

## 📱 Screenshot
Demo Today Extension including MKMapView as demonstration for the possibility of including a map/telemetry gathering in extension

| Extension Demo GUI |
| --- |
| <img width="559" alt="Screen Shot 2020-06-08 at 4 27 07 PM" src="https://user-images.githubusercontent.com/5083390/84089902-1974bb80-a9a5-11ea-8b64-b9a0b28c56aa.png"> |


## 📓  Notes:

1. Although there is a warning, it is not a deal breaker when working in extensions:

There is nothing preventing the SDK/Extension from building/running.


> ld: warning: linking against a dylib which is not safe for use in application extensions: /Users/danemiluski/Library/Developer/Xcode/DerivedData/MapboxMobileEvents-gtwngrjytwknvkfqciqcsoxcqjvr/Build/Products/Debug-iphonesimulator/MapboxMobileEvents.framework/MapboxMobileEvents

To enable friendlier App Extension usage though, we can signify we support app extension API only via this setting, which requires we don't require accessing SharedApplication api.

| Project App Extension Friendly Option | Errors Shown if chosen |
| --- | --- |
| <img width="680" alt="Screen Shot 2020-06-08 at 5 01 26 PM" src="https://user-images.githubusercontent.com/5083390/84091633-e1bc4280-a9a9-11ea-981b-2ab7aba69b1a.png"> | <img width="1680" alt="Screen Shot 2020-06-08 at 5 11 37 PM" src="https://user-images.githubusercontent.com/5083390/84092132-63f93680-a9ab-11ea-9f6b-4dd31bdcca61.png"> |

This can be worked around by injecting a protocol conforming wrapped item for UIApplication or NSExtension handling similar to what was done in the [beta+refactor branch](https://github.com/mapbox/mapbox-events-ios/blob/dane/beta%2Brefactor/MapboxMobileEvents/MMEUIApplicationWrapper.m#L4) did to enable testing, of which extensions are unable to support the longer running tasks. If deemed useful though, extensions could still send backtround URLSession Tasks via a background URLSession config.

2. Upon Testing, I did notice that the NSUserDefault persistent keys did not transfer between extension/app.  Will follow up to see if an app group in the TestHost enables the sharing.