### PR TITLE
[Issue 738] Include OS/Processor Info in UserAgent

### DIFF
--- a/MapboxMobileEvents.xcodeproj/project.pbxproj
+++ b/MapboxMobileEvents.xcodeproj/project.pbxproj
@@ -232,6 +232,9 @@
 		CF93A6582241EDD500BBA199 /* MMECertPin.m in Sources */ = {isa = PBXBuildFile; fileRef = CF93A6562241EDD500BBA199 /* MMECertPin.m */; };
 		CF93A6592241EDD500BBA199 /* MMECertPin.m in Sources */ = {isa = PBXBuildFile; fileRef = CF93A6562241EDD500BBA199 /* MMECertPin.m */; platformFilter = ios; };
 		CF93A65B2241EDD500BBA199 /* MMECertPin.h in Headers */ = {isa = PBXBuildFile; fileRef = CF93A6572241EDD500BBA199 /* MMECertPin.h */; };
+		F43A8823249ACC030055C04F /* NSProcessInfo+SystemInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = F43A8821249ACC030055C04F /* NSProcessInfo+SystemInfo.h */; };
+		F43A8824249ACC030055C04F /* NSProcessInfo+SystemInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = F43A8822249ACC030055C04F /* NSProcessInfo+SystemInfo.m */; };
+		F43A8826249ACDB60055C04F /* NSProcessInfoTests+SystemInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = F43A8825249ACDB60055C04F /* NSProcessInfoTests+SystemInfo.m */; };
 		F44600AF249023A6003B297C /* NotificationCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F446009924902382003B297C /* NotificationCenter.framework */; };
 		F44600B3249023A6003B297C /* TodayViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F44600B2249023A6003B297C /* TodayViewController.m */; };
 		F44600B6249023A6003B297C /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F44600B4249023A6003B297C /* MainInterface.storyboard */; };
@@ -496,6 +499,9 @@
 		CF93A6562241EDD500BBA199 /* MMECertPin.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MMECertPin.m; sourceTree = "<group>"; };
 		CF93A6572241EDD500BBA199 /* MMECertPin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MMECertPin.h; sourceTree = "<group>"; };
 		CF93A66222488A4500BBA199 /* MMECertPinTests.m */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; path = MMECertPinTests.m; sourceTree = "<group>"; };
+		F43A8821249ACC030055C04F /* NSProcessInfo+SystemInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSProcessInfo+SystemInfo.h"; sourceTree = "<group>"; };
+		F43A8822249ACC030055C04F /* NSProcessInfo+SystemInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSProcessInfo+SystemInfo.m"; sourceTree = "<group>"; };
+		F43A8825249ACDB60055C04F /* NSProcessInfoTests+SystemInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSProcessInfoTests+SystemInfo.m"; sourceTree = "<group>"; };
 		F446009924902382003B297C /* NotificationCenter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NotificationCenter.framework; path = System/Library/Frameworks/NotificationCenter.framework; sourceTree = SDKROOT; };
 		F44600AE249023A6003B297C /* TodayWidget.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = TodayWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		F44600B1249023A6003B297C /* TodayViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TodayViewController.h; sourceTree = "<group>"; };
@@ -681,6 +687,8 @@
 				F4684FF32432A1610079B389 /* NSBundle+MMEMobileEvents.m */,
 				40F133521F20051E007B4096 /* NSData+MMEGZIP.h */,
 				40F133511F20051E007B4096 /* NSData+MMEGZIP.m */,
+				F43A8821249ACC030055C04F /* NSProcessInfo+SystemInfo.h */,
+				F43A8822249ACC030055C04F /* NSProcessInfo+SystemInfo.m */,
 				9CF0003E2370D674009A2700 /* NSString+MMEVersions.h */,
 				9CF0003D2370D674009A2700 /* NSString+MMEVersions.m */,
 				9CDC34BF234FD78200852FF0 /* NSUserDefaults+MMEConfiguration_Private.h */,
@@ -843,6 +851,7 @@
 				40FB437F1EFAFDCF00EC5BC0 /* MMEXCTests-Info.plist */,
 				9CF000422370D7B2009A2700 /* NSString+MMEVersions_Tests.m */,
 				9CDC34BA234FD36E00852FF0 /* NSUserDefaults+MMEConfigurationTests.m */,
+				F43A8825249ACDB60055C04F /* NSProcessInfoTests+SystemInfo.m */,
 				ACAF8D26238DDED20033745A /* MMEAPIClientTests.m */,
 				AC69502C238E000C00D095EB /* MMELocationManagerTests.m */,
 				AC03B2C723AC477A0043271D /* MMEMetricsManagerTests.m */,
@@ -905,6 +914,7 @@
 				AC1B091122137BB000DB56C8 /* CLLocationManager+MMEMobileEvents.h in Headers */,
 				409115351F16BCD200F4250B /* MMECategoryLoader.h in Headers */,
 				40AE585E1EA93B3A0046B437 /* MMECommonEventData.h in Headers */,
+				F43A8823249ACC030055C04F /* NSProcessInfo+SystemInfo.h in Headers */,
 				AC61FA5C217A04CC008519F5 /* MMEMetrics.h in Headers */,
 				40FB437C1EFAFAE900EC5BC0 /* MMETimerManager.h in Headers */,
 				AC2C715E2112408A004179E0 /* MMEDispatchManager.h in Headers */,
@@ -1266,6 +1276,7 @@
 				40AE586A1EA953970046B437 /* CLLocation+MMEMobileEvents.m in Sources */,
 				AC1B091222137BB000DB56C8 /* CLLocationManager+MMEMobileEvents.m in Sources */,
 				40AE58721EAA87960046B437 /* MMEAPIClient.m in Sources */,
+				F43A8824249ACC030055C04F /* NSProcessInfo+SystemInfo.m in Sources */,
 				CF93A6582241EDD500BBA199 /* MMECertPin.m in Sources */,
 				40AE585F1EA93B3A0046B437 /* MMECommonEventData.m in Sources */,
 				403835031F7AF145004205B9 /* MMEDependencyManager.m in Sources */,
@@ -1290,6 +1301,7 @@
 				AC03B2C623AB05F00043271D /* MMENSURLSessionWrapperFake.m in Sources */,
 				9CDC34BE234FD62A00852FF0 /* MMEBundleInfoFake.m in Sources */,
 				AC03B2C523A851410043271D /* MMEUIApplicationWrapperFake.m in Sources */,
+				F43A8826249ACDB60055C04F /* NSProcessInfoTests+SystemInfo.m in Sources */,
 				4052C4F31EFB4A740044E2FF /* MMETimerManagerFake.m in Sources */,
 				9C3F931223512F1A00F99907 /* MMETestStub.m in Sources */,
 				9C3F931423512F1A00F99907 /* MMEServiceFixture.m in Sources */,

--- a/MapboxMobileEvents/Categories/NSProcessInfo+SystemInfo.h
+++ b/MapboxMobileEvents/Categories/NSProcessInfo+SystemInfo.h
@@ -1,0 +1,21 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NSProcessInfo (SystemInfo)
+
+/*! Human Readable Description of the of device processor */
++ (NSString *)mme_processorTypeDescription;
+
+/*!
+ @brief Human Readable Description of the CPU
+ @param type Type of the processor
+ @param subtype Subtype of the processor
+ @returns Human readable Descriptin of the device processor
+ @discussion Source Types provided by document https://opensource.apple.com/source/xnu/xnu-792/osfmk/mach/machine.h.auto.html
+ */
++ (NSString*)mme_stringForProcessorType:(NSInteger)type subtype:(NSInteger)subtype;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MapboxMobileEvents/Categories/NSProcessInfo+SystemInfo.h
+++ b/MapboxMobileEvents/Categories/NSProcessInfo+SystemInfo.h
@@ -4,11 +4,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface NSProcessInfo (SystemInfo)
 
-/*! Human Readable Description of the of device processor */
+/*! Human readable description of the Operating system and version */
++ (NSString *)mme_operatingSystemVersion;
+
+/*! Human readable Description of the of device processor */
 + (NSString *)mme_processorTypeDescription;
 
 /*!
- @brief Human Readable Description of the CPU
+ @brief Human readable Description of the CPU
  @param type Type of the processor
  @param subtype Subtype of the processor
  @returns Human readable Descriptin of the device processor

--- a/MapboxMobileEvents/Categories/NSProcessInfo+SystemInfo.m
+++ b/MapboxMobileEvents/Categories/NSProcessInfo+SystemInfo.m
@@ -1,9 +1,26 @@
 #import "NSProcessInfo+SystemInfo.h"
+#if TARGET_OS_IOS || TARGET_OS_TVOS
+#import <UIKit/UIKit.h>
+#elif TARGET_OS_MACOS
+#import <AppKit/AppKit.h>
+#endif
 #include <sys/types.h>
 #include <sys/sysctl.h>
 #include <mach/machine.h>
 
 @implementation NSProcessInfo (SystemInfo)
+
++ (NSString *)mme_operatingSystemVersion {
+    NSString *osVersion = nil;
+
+#if TARGET_OS_IOS || TARGET_OS_TVOS
+    osVersion = [NSString stringWithFormat:@"%@ %@", UIDevice.currentDevice.systemName, UIDevice.currentDevice.systemVersion];
+#elif TARGET_OS_MACOS
+    osVersion = NSProcessInfo.processInfo.operatingSystemVersionString;
+#endif
+
+    return osVersion;
+}
 
 + (NSString*)mme_stringForProcessorType:(NSInteger)type subtype:(NSInteger)subtype {
 

--- a/MapboxMobileEvents/Categories/NSProcessInfo+SystemInfo.m
+++ b/MapboxMobileEvents/Categories/NSProcessInfo+SystemInfo.m
@@ -1,0 +1,86 @@
+#import "NSProcessInfo+SystemInfo.h"
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <mach/machine.h>
+
+@implementation NSProcessInfo (SystemInfo)
+
++ (NSString*)mme_stringForProcessorType:(NSInteger)type subtype:(NSInteger)subtype {
+
+    // Scratch String to build description. Ensures non-nil
+    NSMutableString *processorDescription = [[NSMutableString alloc] init];
+
+    // values for cputype and cpusubtype defined in mach/machine.h
+    // https://opensource.apple.com/source/dyld/dyld-635.2/launch-cache/MachOFileAbstraction.hpp.auto.html
+    if (type == CPU_TYPE_X86_64) {
+        [processorDescription appendString:@"x86_64"];
+    } else if (type == CPU_TYPE_X86) {
+        [processorDescription appendString:@"x86"];
+
+        switch(subtype) {
+            case CPU_SUBTYPE_X86_64_ALL:
+                [processorDescription appendString:@"_64"];
+                break;
+            case CPU_SUBTYPE_X86_ARCH1:
+                [processorDescription appendString:@"_64"];
+                break;
+            case CPU_SUBTYPE_X86_64_H:
+                [processorDescription appendString:@"_64"];
+                break;
+        }
+
+    } else if (type == CPU_TYPE_ARM) {
+        [processorDescription appendString:@"arm"];
+        switch(subtype) {
+            case CPU_SUBTYPE_ARM_V6:
+                [processorDescription appendString:@"v6"];
+                break;
+            case CPU_SUBTYPE_ARM_V7:
+                [processorDescription appendString:@"v7"];
+                break;
+            case CPU_SUBTYPE_ARM_V7F:
+                [processorDescription appendString:@"v7f"];
+                break;
+            case CPU_SUBTYPE_ARM_V7S:
+                [processorDescription appendString:@"v7s"];
+                break;
+            case CPU_SUBTYPE_ARM_V7K:
+                [processorDescription appendString:@"v7k"];
+                break;
+            case CPU_SUBTYPE_ARM_V8:
+                [processorDescription appendString:@"v8"];
+                break;
+        }
+    } else if (type == CPU_TYPE_ARM64) {
+        [processorDescription appendString:@"arm64"];
+        switch(subtype)
+        {
+            case CPU_SUBTYPE_ARM64_V8:
+                [processorDescription appendString:@"v8"];
+                break;
+            case CPU_SUBTYPE_ARM64E:
+                [processorDescription appendString:@"e"];
+                break;
+        }
+    }
+
+    return processorDescription;
+}
+
++ (NSString *)mme_processorTypeDescription {
+    size_t size;
+    cpu_type_t type;
+    cpu_subtype_t subtype;
+
+    // Get Type
+    size = sizeof(type);
+    sysctlbyname("hw.cputype", &type, &size, NULL, 0);
+
+    // Get Subtype
+    size = sizeof(subtype);
+    sysctlbyname("hw.cpusubtype", &subtype, &size, NULL, 0);
+
+    return [self mme_stringForProcessorType:type subtype: subtype];
+}
+
+@end

--- a/MapboxMobileEvents/Categories/NSUserDefaults+MMEConfiguration.m
+++ b/MapboxMobileEvents/Categories/NSUserDefaults+MMEConfiguration.m
@@ -287,13 +287,12 @@ NS_ASSUME_NONNULL_BEGIN
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
 
-        userAgent = [NSString stringWithFormat:@"%@/%@ (%@; v%@; %@ %@; %@)",
+        userAgent = [NSString stringWithFormat:@"%@/%@ (%@; v%@; %@; %@)",
             NSBundle.mme_mainBundle.infoDictionary[(id)kCFBundleNameKey] ?: NSBundle.mme_mainBundle.bundlePath.lastPathComponent.stringByDeletingPathExtension,
             NSBundle.mme_mainBundle.mme_bundleVersionString,
             NSBundle.mme_mainBundle.bundleIdentifier,
             NSBundle.mme_mainBundle.infoDictionary[(id)kCFBundleVersionKey],
-            UIDevice.currentDevice.systemName,
-            UIDevice.currentDevice.systemVersion,
+            [NSProcessInfo mme_operatingSystemVersion],
             [NSProcessInfo mme_processorTypeDescription]
         ];
         

--- a/MapboxMobileEvents/Categories/NSUserDefaults+MMEConfiguration.m
+++ b/MapboxMobileEvents/Categories/NSUserDefaults+MMEConfiguration.m
@@ -285,11 +285,14 @@ NS_ASSUME_NONNULL_BEGIN
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
 
-        userAgent = [NSString stringWithFormat:@"%@/%@ (%@; v%@)",
+        userAgent = [NSString stringWithFormat:@"%@/%@ (%@; v%@; %@ %@)",
             NSBundle.mme_mainBundle.infoDictionary[(id)kCFBundleNameKey] ?: NSBundle.mme_mainBundle.bundlePath.lastPathComponent.stringByDeletingPathExtension,
             NSBundle.mme_mainBundle.mme_bundleVersionString,
             NSBundle.mme_mainBundle.bundleIdentifier,
-            NSBundle.mme_mainBundle.infoDictionary[(id)kCFBundleVersionKey]];
+            NSBundle.mme_mainBundle.infoDictionary[(id)kCFBundleVersionKey],
+            UIDevice.currentDevice.systemName,
+            UIDevice.currentDevice.systemVersion
+            ];
         
         // check all loaded frameworks for mapbox frameworks, record their bundleIdentifier
         NSMutableSet *loadedMapboxBundleIds = NSMutableSet.new;

--- a/MapboxMobileEvents/Categories/NSUserDefaults+MMEConfiguration.m
+++ b/MapboxMobileEvents/Categories/NSUserDefaults+MMEConfiguration.m
@@ -1,9 +1,11 @@
 #import <CommonCrypto/CommonDigest.h>
 
+
 #import "MMEConstants.h"
 #import "MMEDate.h"
 #import "MMEEventLogger.h"
 #import "NSBundle+MMEMobileEvents.h"
+#import "NSProcessInfo+SystemInfo.h"
 #import "NSString+MMEVersions.h"
 #import "NSUserDefaults+MMEConfiguration.h"
 #import "NSUserDefaults+MMEConfiguration_Private.h"
@@ -285,14 +287,15 @@ NS_ASSUME_NONNULL_BEGIN
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
 
-        userAgent = [NSString stringWithFormat:@"%@/%@ (%@; v%@; %@ %@)",
+        userAgent = [NSString stringWithFormat:@"%@/%@ (%@; v%@; %@ %@; %@)",
             NSBundle.mme_mainBundle.infoDictionary[(id)kCFBundleNameKey] ?: NSBundle.mme_mainBundle.bundlePath.lastPathComponent.stringByDeletingPathExtension,
             NSBundle.mme_mainBundle.mme_bundleVersionString,
             NSBundle.mme_mainBundle.bundleIdentifier,
             NSBundle.mme_mainBundle.infoDictionary[(id)kCFBundleVersionKey],
             UIDevice.currentDevice.systemName,
-            UIDevice.currentDevice.systemVersion
-            ];
+            UIDevice.currentDevice.systemVersion,
+            [NSProcessInfo mme_processorTypeDescription]
+        ];
         
         // check all loaded frameworks for mapbox frameworks, record their bundleIdentifier
         NSMutableSet *loadedMapboxBundleIds = NSMutableSet.new;

--- a/Tests/NSProcessInfoTests+SystemInfo.m
+++ b/Tests/NSProcessInfoTests+SystemInfo.m
@@ -1,0 +1,38 @@
+#import <XCTest/XCTest.h>
+#import "NSProcessInfo+SystemInfo.h"
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <mach/machine.h>
+
+
+@interface NSProcessInfoTests : XCTestCase
+
+@end
+
+@implementation NSProcessInfoTests
+
+- (void)testProcessorType {
+
+    // CPUs sourced from machine.h
+    // https://opensource.apple.com/source/xnu/xnu-792/osfmk/mach/machine.h.auto.html
+    XCTAssertEqualObjects([NSProcessInfo mme_stringForProcessorType:CPU_TYPE_X86 subtype:CPU_SUBTYPE_X86_ALL], @"x86_64");
+    XCTAssertEqualObjects([NSProcessInfo mme_stringForProcessorType:CPU_TYPE_X86 subtype:CPU_SUBTYPE_X86_64_H], @"x86_64");
+    XCTAssertEqualObjects([NSProcessInfo mme_stringForProcessorType:CPU_TYPE_X86_64 subtype:CPU_SUBTYPE_X86_ALL], @"x86_64");
+
+    // ARM CPUs
+    XCTAssertEqualObjects([NSProcessInfo mme_stringForProcessorType:CPU_TYPE_ARM subtype:CPU_SUBTYPE_ARM_ALL], @"arm");
+    XCTAssertEqualObjects([NSProcessInfo mme_stringForProcessorType:CPU_TYPE_ARM subtype:CPU_SUBTYPE_ARM_V6], @"armv6");
+    XCTAssertEqualObjects([NSProcessInfo mme_stringForProcessorType:CPU_TYPE_ARM subtype:CPU_SUBTYPE_ARM_V7], @"armv7");
+    XCTAssertEqualObjects([NSProcessInfo mme_stringForProcessorType:CPU_TYPE_ARM subtype:CPU_SUBTYPE_ARM_V7F], @"armv7f");
+    XCTAssertEqualObjects([NSProcessInfo mme_stringForProcessorType:CPU_TYPE_ARM subtype:CPU_SUBTYPE_ARM_V7S], @"armv7s");
+    XCTAssertEqualObjects([NSProcessInfo mme_stringForProcessorType:CPU_TYPE_ARM subtype:CPU_SUBTYPE_ARM_V7K], @"armv7k");
+    XCTAssertEqualObjects([NSProcessInfo mme_stringForProcessorType:CPU_TYPE_ARM subtype:CPU_SUBTYPE_ARM_V8], @"armv8");
+
+    // ARM 64 CPUs
+    XCTAssertEqualObjects([NSProcessInfo mme_stringForProcessorType:CPU_TYPE_ARM64 subtype:CPU_SUBTYPE_ARM64_ALL], @"arm64");
+    XCTAssertEqualObjects([NSProcessInfo mme_stringForProcessorType:CPU_TYPE_ARM64 subtype:CPU_SUBTYPE_ARM64_V8], @"arm64v8");
+    XCTAssertEqualObjects([NSProcessInfo mme_stringForProcessorType:CPU_TYPE_ARM64 subtype:CPU_SUBTYPE_ARM64E], @"arm64e");
+}
+
+
+@end


### PR DESCRIPTION
## 🔧 Issue:
https://github.com/mapbox/mobile-telemetry/issues/738

## 🥅 Goal:
Having information about the OS and CPU can help us understand our market segmentation for devices. As well as provide insights into the numbers of users running on simulators or desktop..

## 🗺️  Approach:
Leverage UIDevice / NSProcessInfo / sys info to extract beneficial information

## 👨‍⚕️ Changes:
+ Add NSProcessorInfo category methods to host processor and operating system helpers
+ Include OS/Version in root user agent
+ Include Processor info in user agent

## Before/After
| User Agent (Before) | User Agent (After) |
| --- | --- |
|  MMETestHost/1.0.0 (com.mapbox.MMETestHost; v1) MapboxMobileEvents/0.10.2 (com.mapbox.MapboxMobileEvents; v1) | MMETestHost/1.0.0 (com.mapbox.MMETestHost; v1; iOS 13.5; ARME) MapboxMobileEvents/0.10.2 (com.mapbox.MapboxMobileEvents; v1) |
| | (Includes extra `iOS 13.5; ARME`) |