### PR TITLE
Add UA filter

### DIFF
--- a/MapboxMobileEvents/Categories/NSString+MMEVersions.h
+++ b/MapboxMobileEvents/Categories/NSString+MMEVersions.h
@@ -10,6 +10,9 @@ extern NSInteger const MMESemverInvalidVersion;
 ///
 @interface NSString (MMEVersions)
 
+/// filters out set of US-ASCII visual characters not allowed in user agent
+- (NSString *)mme_stringByRemovingNonUserAgentTokenCharacters;
+
 /// YES if this string complies with the semver specification
 - (BOOL) mme_isSemverString;
 

--- a/MapboxMobileEvents/Categories/NSString+MMEVersions.m
+++ b/MapboxMobileEvents/Categories/NSString+MMEVersions.m
@@ -46,6 +46,11 @@ typedef enum {
 
 @implementation NSString (MMEVersions)
 
+- (NSString *)mme_stringByRemovingNonUserAgentTokenCharacters {
+return [[self componentsSeparatedByCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@" (),/:;<=>?@[]{}\"\\"]]
+                       componentsJoinedByString:@""];
+}
+
 + (NSRegularExpression *)mme_semverExpression {
     static NSRegularExpression *semverExpression = nil;
     static dispatch_once_t onceToken;

--- a/MapboxMobileEvents/Categories/NSString+MMEVersions.m
+++ b/MapboxMobileEvents/Categories/NSString+MMEVersions.m
@@ -47,7 +47,7 @@ typedef enum {
 @implementation NSString (MMEVersions)
 
 - (NSString *)mme_stringByRemovingNonUserAgentTokenCharacters {
-return [[self componentsSeparatedByCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@" (),/:;<=>?@[]{}\"\\"]]
+return [[self componentsSeparatedByCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"(),/:;<=>?@[]{}\"\\"]]
                        componentsJoinedByString:@""];
 }
 

--- a/MapboxMobileEvents/Categories/NSUserDefaults+MMEConfiguration.m
+++ b/MapboxMobileEvents/Categories/NSUserDefaults+MMEConfiguration.m
@@ -286,10 +286,10 @@ NS_ASSUME_NONNULL_BEGIN
     dispatch_once(&onceToken, ^{
 
         userAgent = [NSString stringWithFormat:@"%@/%@ (%@; v%@)",
-            NSBundle.mme_mainBundle.infoDictionary[(id)kCFBundleNameKey] ?: NSBundle.mme_mainBundle.bundlePath.lastPathComponent.stringByDeletingPathExtension,
-            NSBundle.mme_mainBundle.mme_bundleVersionString,
-            NSBundle.mme_mainBundle.bundleIdentifier,
-            NSBundle.mme_mainBundle.infoDictionary[(id)kCFBundleVersionKey]];
+                     [[NSBundle.mme_mainBundle objectForInfoDictionaryKey:(id)kCFBundleNameKey] mme_stringByRemovingNonUserAgentTokenCharacters] ?: NSBundle.mme_mainBundle.bundlePath.lastPathComponent.stringByDeletingPathExtension.mme_stringByRemovingNonUserAgentTokenCharacters,
+                     NSBundle.mme_mainBundle.mme_bundleVersionString.mme_stringByRemovingNonUserAgentTokenCharacters,
+                     NSBundle.mme_mainBundle.bundleIdentifier.mme_stringByRemovingNonUserAgentTokenCharacters,
+                     [[NSBundle.mme_mainBundle objectForInfoDictionaryKey:(id)kCFBundleVersionKey] mme_stringByRemovingNonUserAgentTokenCharacters]];
         
         // check all loaded frameworks for mapbox frameworks, record their bundleIdentifier
         NSMutableSet *loadedMapboxBundleIds = NSMutableSet.new;
@@ -306,10 +306,10 @@ NS_ASSUME_NONNULL_BEGIN
         for (NSString *bundleId in sortedBundleIds) {
             NSBundle *loaded = [NSBundle bundleWithIdentifier:bundleId];
             NSString *uaFragment = [NSString stringWithFormat:@" %@/%@ (%@; v%@)",
-                loaded.infoDictionary[(id)kCFBundleNameKey] ?: loaded.bundlePath.lastPathComponent.stringByDeletingPathExtension,
-                loaded.mme_bundleVersionString,
-                loaded.bundleIdentifier,
-                loaded.infoDictionary[(id)kCFBundleVersionKey]];
+                [[loaded objectForInfoDictionaryKey:(id)kCFBundleNameKey] mme_stringByRemovingNonUserAgentTokenCharacters] ?: NSBundle.mme_mainBundle.bundlePath.lastPathComponent.stringByDeletingPathExtension.mme_stringByRemovingNonUserAgentTokenCharacters,
+                loaded.mme_bundleVersionString.mme_stringByRemovingNonUserAgentTokenCharacters,
+                loaded.bundleIdentifier.mme_stringByRemovingNonUserAgentTokenCharacters,
+                [[loaded objectForInfoDictionaryKey:(id)kCFBundleVersionKey] mme_stringByRemovingNonUserAgentTokenCharacters]];
             userAgent = [userAgent stringByAppendingString:uaFragment];
         }
     });
@@ -321,11 +321,11 @@ NS_ASSUME_NONNULL_BEGIN
     NSString *legacyUAString = (NSString *)[self mme_objectForVolatileKey:MMELegacyUserAgent];
     if (!legacyUAString) {
         legacyUAString= [NSString stringWithFormat:@"%@/%@/%@ %@/%@",
-            NSBundle.mme_mainBundle.bundleIdentifier,
-            NSBundle.mme_mainBundle.mme_bundleVersionString,
-            [NSBundle.mme_mainBundle objectForInfoDictionaryKey:(id)kCFBundleVersionKey],
-            self.mme_legacyUserAgentBase,
-            self.mme_legacyHostSDKVersion];
+            NSBundle.mme_mainBundle.bundleIdentifier.mme_stringByRemovingNonUserAgentTokenCharacters,
+            NSBundle.mme_mainBundle.mme_bundleVersionString.mme_stringByRemovingNonUserAgentTokenCharacters,
+            [[NSBundle.mme_mainBundle objectForInfoDictionaryKey:(id)kCFBundleVersionKey] mme_stringByRemovingNonUserAgentTokenCharacters],
+            self.mme_legacyUserAgentBase.mme_stringByRemovingNonUserAgentTokenCharacters,
+            self.mme_legacyHostSDKVersion.mme_stringByRemovingNonUserAgentTokenCharacters];
         [self mme_setObject:legacyUAString forVolatileKey:MMELegacyUserAgent];
     }
     return legacyUAString;

--- a/Tests/NSString+MMEVersions_Tests.m
+++ b/Tests/NSString+MMEVersions_Tests.m
@@ -133,8 +133,17 @@
 }
 
 - (void)test011_invalidDelimitersInString {
-    NSString *badString = @"user-agent-base (),/:;<=>?@[]{}\"\\";
-    NSString *goodString = @"user-agent-base";
+    NSString *badString = @"user agent base(),/:;<=>?@[]{}\"\\";
+    NSString *goodString = @"user agent base";
+    XCTAssert([badString.mme_stringByRemovingNonUserAgentTokenCharacters
+              isEqualToString:goodString]);
+    
+//    com.conduent.mrparking.debug.dev/1.0-development dev-api -build 03112020 35144 PM/1 mapbox-android-location/4.5.1
+}
+
+- (void)test012_invalidUserAgent {
+    NSString *badString = @"1.0-development (dev-api) -build 03/11/2020 3:51:44 PM";
+    NSString *goodString = @"1.0-development dev-api -build 03112020 35144 PM";
     XCTAssert([badString.mme_stringByRemovingNonUserAgentTokenCharacters
               isEqualToString:goodString]);
 }

--- a/Tests/NSString+MMEVersions_Tests.m
+++ b/Tests/NSString+MMEVersions_Tests.m
@@ -132,4 +132,11 @@
     XCTAssertFalse([fakeBundle.mme_bundleVersionString mme_isSemverString]);
 }
 
+- (void)test011_invalidDelimitersInString {
+    NSString *badString = @"user-agent-base (),/:;<=>?@[]{}\"\\";
+    NSString *goodString = @"user-agent-base";
+    XCTAssert([badString.mme_stringByRemovingNonUserAgentTokenCharacters
+              isEqualToString:goodString]);
+}
+
 @end


### PR DESCRIPTION
Simple change to remove special characters from our user agents. `(),/:;<=>?@[]{}"\` are being removed from every string used to build a user agent.