### PR TITLE
Bump Xcode to 11.6.0 and store release artifact

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,11 @@ jobs:
   build:
 
     macos:
-      xcode: 11.4.1
+      xcode: 11.6.0
 
     steps:
       - checkout
       - run: make ci-run
+      - run: make create-static
+      - store_artifacts:
+          path: build/mapbox-events-ios-static.zip


### PR DESCRIPTION
Storing artifact to get deterministic builds for release process
Bumped to Xcode 11.6.0 which is the latest stable Xcode release

cc @alfwatt 