### PR TITLE
[build] Remove unneeded command from the Makefile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,6 @@ jobs:
 
     steps:
       - checkout
-      - run: make ci-run
-      - run: make create-static
+      - run: make build
       - store_artifacts:
           path: build/mapbox-events-ios-static.zip

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,3 @@ test:
 .PHONY: docs
 docs: $(DOCS_DIR) headerdoc docindex
 	open $(DOCS_INDEX)
-
-.PHONY: ci-run
-ci-run: build


### PR DESCRIPTION
Both `build` and `ci-run` commands are same in Makefile, so removing the ci-run. Also, 'make build' does create the static binary, so there is no need to run 'make create-static' on the CI.
