### PR TITLE
Add CocoaPods and Carthage integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,3 +26,9 @@ jobs:
       - run:
           name: Test
           command: xcodebuild -project MapboxMobileEventsTests.xcodeproj -scheme MMETestHost build test -destination 'platform=iOS Simulator,name=iPhone 11,OS=latest' GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES
+      - run:
+          name: Test CocoaPods
+          command: Tests/Integration/test_cocoapods.sh
+      - run:
+          name: Test Carthage
+          command: Tests/Integration/test_carthage.sh

--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,7 @@ playground.xcworkspace
 # Add this line if you want to avoid checking in source code from Carthage dependencies.
 # Carthage/Checkouts
 Cartfile.resolved
-Carthage/
+Carthage
 
 # fastlane
 #

--- a/Tests/Integration/.gitignore
+++ b/Tests/Integration/.gitignore
@@ -1,0 +1,1 @@
+!Carthage

--- a/Tests/Integration/Carthage/.gitignore
+++ b/Tests/Integration/Carthage/.gitignore
@@ -1,0 +1,2 @@
+Carthage
+*.xcodeproj

--- a/Tests/Integration/Carthage/Cartfile
+++ b/Tests/Integration/Carthage/Cartfile
@@ -1,0 +1,1 @@
+git "@PATH@" "HEAD" 

--- a/Tests/Integration/Carthage/Sources/AppDelegate.swift
+++ b/Tests/Integration/Carthage/Sources/AppDelegate.swift
@@ -1,0 +1,1 @@
+../../Sources/AppDelegate.swift

--- a/Tests/Integration/Carthage/Sources/Info.plist
+++ b/Tests/Integration/Carthage/Sources/Info.plist
@@ -1,0 +1,1 @@
+../../Sources/Info.plist

--- a/Tests/Integration/Carthage/project.yml
+++ b/Tests/Integration/Carthage/project.yml
@@ -1,0 +1,13 @@
+name: CarthageTest
+options:
+  bundleIdPrefix: com.mapbox.common.events.carthage
+targets:
+  CarthageTest:
+    type: application
+    platform: iOS
+    deploymentTarget: "9.0"
+    sources: [Sources]
+    dependencies:
+      - framework: Carthage/Build/iOS/MapboxMobileEvents.framework
+    settings:
+        DEVELOPMENT_TEAM: "GJZR2MEM28"

--- a/Tests/Integration/CocoaPods/.gitignore
+++ b/Tests/Integration/CocoaPods/.gitignore
@@ -1,0 +1,5 @@
+Pods
+Podfile.lock
+Gemfile.lock
+*.xcodeproj
+*.xcworkspace

--- a/Tests/Integration/CocoaPods/Gemfile
+++ b/Tests/Integration/CocoaPods/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'cocoapods'

--- a/Tests/Integration/CocoaPods/Podfile
+++ b/Tests/Integration/CocoaPods/Podfile
@@ -1,0 +1,5 @@
+platform :ios, '9.0'
+
+target 'PodInstall' do
+  pod 'MapboxMobileEvents', :path => '../../../'
+end

--- a/Tests/Integration/CocoaPods/Sources/AppDelegate.swift
+++ b/Tests/Integration/CocoaPods/Sources/AppDelegate.swift
@@ -1,0 +1,1 @@
+../../Sources/AppDelegate.swift

--- a/Tests/Integration/CocoaPods/Sources/Info.plist
+++ b/Tests/Integration/CocoaPods/Sources/Info.plist
@@ -1,0 +1,1 @@
+../../Sources/Info.plist

--- a/Tests/Integration/CocoaPods/project.yml
+++ b/Tests/Integration/CocoaPods/project.yml
@@ -1,0 +1,13 @@
+name: PodInstall
+options:
+  bundleIdPrefix: com.mapbox.common.events.PodInstall
+targets:
+  PodInstall:
+    type: application
+    platform: iOS
+    deploymentTarget: "9.0"
+    sources: [Sources]
+    settings:
+        DEVELOPMENT_TEAM: "GJZR2MEM28"
+        SUPPORTS_MACCATALYST: YES
+        DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER: YES

--- a/Tests/Integration/Sources/AppDelegate.swift
+++ b/Tests/Integration/Sources/AppDelegate.swift
@@ -1,0 +1,16 @@
+import UIKit
+import MapboxMobileEvents
+
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate, MMEEventsManagerDelegate {
+    var window: UIWindow?
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+
+        MMEEventsManager.shared().delegate = self
+        assert(MMEEventsManager.shared().delegate != nil)
+
+        return true
+    }
+}

--- a/Tests/Integration/Sources/Info.plist
+++ b/Tests/Integration/Sources/Info.plist
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.0.2</string>
+	<key>CFBundleSignature</key>
+	<string>MBGL</string>
+	<key>CFBundleVersion</key>
+	<string>7877</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>MGLMapboxAccessToken</key>
+	<string>$(MAPBOX_ACCESS_TOKEN)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>© 2014–2020 Mapbox</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>The map will display your location. If you choose Always, the map may also use your location when it isn’t visible in order to improve OpenStreetMap and Mapbox products.</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>The map will display your location. The map may also use your location when it isn’t visible in order to improve OpenStreetMap and Mapbox products.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>The map will display your location.</string>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Tests/Integration/test_carthage.sh
+++ b/Tests/Integration/test_carthage.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+set -euo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR="${DIR}/../.."
+pushd "${ROOT_DIR}/Tests/Integration/Carthage"
+
+sed -i '' -e "s|@PATH@|file:///${ROOT_DIR}|g" "${ROOT_DIR}/Tests/Integration/Carthage/Cartfile"
+xcodegen generate
+carthage update --platform iOS --use-netrc
+xcodebuild -project CarthageTest.xcodeproj -scheme CarthageTest -destination 'platform=iOS Simulator,name=iPhone 11,OS=latest' build
+
+popd

--- a/Tests/Integration/test_carthage.sh
+++ b/Tests/Integration/test_carthage.sh
@@ -5,6 +5,10 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR="${DIR}/../.."
 pushd "${ROOT_DIR}/Tests/Integration/Carthage"
 
+if [ -z `which xcodegen` ]; then
+     brew install xcodegen
+fi
+
 sed -i '' -e "s|@PATH@|file:///${ROOT_DIR}|g" "${ROOT_DIR}/Tests/Integration/Carthage/Cartfile"
 xcodegen generate
 carthage update --platform iOS --use-netrc

--- a/Tests/Integration/test_cocoapods.sh
+++ b/Tests/Integration/test_cocoapods.sh
@@ -5,6 +5,10 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR="${DIR}/../.."
 pushd "${ROOT_DIR}/Tests/Integration/CocoaPods"
 
+if [ -z `which xcodegen` ]; then
+    brew install xcodegen
+fi
+
 xcodegen generate
 bundle install
 bundle exec pod install

--- a/Tests/Integration/test_cocoapods.sh
+++ b/Tests/Integration/test_cocoapods.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+set -euo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR="${DIR}/../.."
+pushd "${ROOT_DIR}/Tests/Integration/CocoaPods"
+
+xcodegen generate
+bundle install
+bundle exec pod install
+xcodebuild -workspace PodInstall.xcworkspace -scheme PodInstall -destination 'platform=iOS Simulator,name=iPhone 11,OS=latest' build
+
+popd


### PR DESCRIPTION
Added tests for integrating this library with CocoaPods and Carthage.

What the tests verify is that the podspec is valid and we are able to integrate it into a project and that there's a valid shared scheme Carthage can use to integrate the framework and we can compile an application using one of package managers.

cc @alfwatt @mr1sunshine @nagineni 
