### PR TITLE
Offload heavy request builder work

### DIFF
--- a/MapboxMobileEvents/MMEAPIClient.m
+++ b/MapboxMobileEvents/MMEAPIClient.m
@@ -138,6 +138,11 @@ int const kMMEMaxRequestCount = 1000;
 }
 
 // MARK: - Configuration Service
+void MMEDispatchMainIfNeeded(void (^block)(void))
+{
+    if ([NSThread isMainThread]) { block(); }
+    else { dispatch_sync(dispatch_get_main_queue(), block); }
+}
 
 - (void)startGettingConfigUpdates {
     if (self.isGettingConfigUpdates) {
@@ -146,49 +151,18 @@ int const kMMEMaxRequestCount = 1000;
 
     if (@available(iOS 10.0, macos 10.12, tvOS 10.0, watchOS 3.0, *)) {
         self.configurationUpdateTimer = [NSTimer
-            scheduledTimerWithTimeInterval:NSUserDefaults.mme_configuration.mme_configUpdateInterval
-            repeats:YES
-            block:^(NSTimer * _Nonnull timer) {
+                                         scheduledTimerWithTimeInterval:NSUserDefaults.mme_configuration.mme_configUpdateInterval
+                                         repeats:YES
+                                         block:^(NSTimer * _Nonnull timer) {
+            dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+            dispatch_async(queue, ^{
                 NSURLRequest *request = [self requestForConfiguration];
-                
-                [self.sessionWrapper processRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
-                    [MMEMetricsManager.sharedManager updateReceivedBytes:data.length];
-                    NSHTTPURLResponse *httpResponse = nil;
-                    NSError *statusError = nil;
-                    if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
-                        httpResponse = (NSHTTPURLResponse *)response;
-                        statusError = [self statusErrorFromRequest:request andHTTPResponse:httpResponse];
-                    } else {
-                        statusError = [self unexpectedResponseError:error fromRequest:request andResponse:response];
-                    }
-                    
-                    if (statusError) {
-                        [MMEEventsManager.sharedManager reportError:statusError];
-                    }
-                    else if (data) {
-                        NSError *configError = [NSUserDefaults.mme_configuration mme_updateFromConfigServiceData:data];
-                        if (configError) {
-                            [MMEEventsManager.sharedManager reportError:configError];
-                        }
-                        
-                        // check for time-offset from the server
-                        NSString *dateHeader = httpResponse.allHeaderFields[@"Date"];
-                        if (dateHeader) {
-                            // parse the server date, compute the offset
-                            NSDate *date = [MMEDate.HTTPDateFormatter dateFromString:dateHeader];
-                            if (date) {
-                                [MMEDate recordTimeOffsetFromServer:date];
-                            } // else failed to parse date
-                        }
-                        
-                        NSUserDefaults.mme_configuration.mme_configUpdateDate = MMEDate.date;
-                    }
+                MMEDispatchMainIfNeeded(^{
+                    [self processRequest:request];
+                });
+            });
+        }];
 
-                    [MMEMetricsManager.sharedManager updateMetricsFromEventCount:0 request:request error:error];
-                    [MMEMetricsManager.sharedManager generateTelemetryMetricsEvent];
-                }];
-            }];
-        
         // be power conscious and give this timer a minute of slack so it can be coalesced
         self.configurationUpdateTimer.tolerance = 60;
 
@@ -199,6 +173,45 @@ int const kMMEMaxRequestCount = 1000;
             [self.configurationUpdateTimer fire]; // update now
         }
     }
+}
+
+- (void)processRequest:(NSURLRequest *)request {
+    [self.sessionWrapper processRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+        [MMEMetricsManager.sharedManager updateReceivedBytes:data.length];
+        NSHTTPURLResponse *httpResponse = nil;
+        NSError *statusError = nil;
+        if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
+            httpResponse = (NSHTTPURLResponse *)response;
+            statusError = [self statusErrorFromRequest:request andHTTPResponse:httpResponse];
+        } else {
+            statusError = [self unexpectedResponseError:error fromRequest:request andResponse:response];
+        }
+
+        if (statusError) {
+            [MMEEventsManager.sharedManager reportError:statusError];
+        }
+        else if (data) {
+            NSError *configError = [NSUserDefaults.mme_configuration mme_updateFromConfigServiceData:data];
+            if (configError) {
+                [MMEEventsManager.sharedManager reportError:configError];
+            }
+
+            // check for time-offset from the server
+            NSString *dateHeader = httpResponse.allHeaderFields[@"Date"];
+            if (dateHeader) {
+                // parse the server date, compute the offset
+                NSDate *date = [MMEDate.HTTPDateFormatter dateFromString:dateHeader];
+                if (date) {
+                    [MMEDate recordTimeOffsetFromServer:date];
+                } // else failed to parse date
+            }
+
+            NSUserDefaults.mme_configuration.mme_configUpdateDate = MMEDate.date;
+        }
+
+        [MMEMetricsManager.sharedManager updateMetricsFromEventCount:0 request:request error:error];
+        [MMEMetricsManager.sharedManager generateTelemetryMetricsEvent];
+    }];
 }
 
 - (void)stopGettingConfigUpdates {

--- a/MapboxMobileEvents/MMEEventsManager.m
+++ b/MapboxMobileEvents/MMEEventsManager.m
@@ -88,58 +88,58 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)initializeWithAccessToken:(NSString *)accessToken userAgentBase:(NSString *)userAgentBase hostSDKVersion:(NSString *)hostSDKVersion {
-    @try {
-        if (self.apiClient) {
-            [NSUserDefaults.mme_configuration mme_setAccessToken:accessToken];
-            return;
-        }
-
-        self.apiClient = [[MMEAPIClient alloc] initWithAccessToken:accessToken
-            userAgentBase:userAgentBase
-            hostSDKVersion:hostSDKVersion];
-
-        [self sendPendingTelemetryMetricsEvent];
-
-        __weak __typeof__(self) weakSelf = self;
-        void(^initialization)(void) = ^{
-            __strong __typeof__(weakSelf) strongSelf = weakSelf;
-
-            if (strongSelf == nil) {
+        @try {
+            if (self.apiClient) {
+                [NSUserDefaults.mme_configuration mme_setAccessToken:accessToken];
                 return;
             }
 
-            [NSNotificationCenter.defaultCenter addObserver:strongSelf
-                selector:@selector(pauseOrResumeMetricsCollectionIfRequired)
-                name:UIApplicationDidEnterBackgroundNotification
-                object:nil];
-            [NSNotificationCenter.defaultCenter addObserver:strongSelf
-                selector:@selector(pauseOrResumeMetricsCollectionIfRequired)
-                name:UIApplicationDidBecomeActiveNotification
-                object:nil];
+            self.apiClient = [[MMEAPIClient alloc] initWithAccessToken:accessToken
+                                                         userAgentBase:userAgentBase
+                                                        hostSDKVersion:hostSDKVersion];
 
-            if (@available(iOS 9.0, *)) {
+            [self sendPendingTelemetryMetricsEvent];
+
+            __weak __typeof__(self) weakSelf = self;
+            void(^initialization)(void) = ^{
+                __strong __typeof__(weakSelf) strongSelf = weakSelf;
+
+                if (strongSelf == nil) {
+                    return;
+                }
+
                 [NSNotificationCenter.defaultCenter addObserver:strongSelf
-                    selector:@selector(powerStateDidChange:)
-                    name:NSProcessInfoPowerStateDidChangeNotification
-                    object:nil];
-            }
+                                                       selector:@selector(pauseOrResumeMetricsCollectionIfRequired)
+                                                           name:UIApplicationDidEnterBackgroundNotification
+                                                         object:nil];
+                [NSNotificationCenter.defaultCenter addObserver:strongSelf
+                                                       selector:@selector(pauseOrResumeMetricsCollectionIfRequired)
+                                                           name:UIApplicationDidBecomeActiveNotification
+                                                         object:nil];
 
-            strongSelf.paused = YES;
-            strongSelf.locationManager = [[MMELocationManager alloc] init];
-            strongSelf.locationManager.delegate = strongSelf;
-            [strongSelf resumeMetricsCollection];
+                if (@available(iOS 9.0, *)) {
+                    [NSNotificationCenter.defaultCenter addObserver:strongSelf
+                                                           selector:@selector(powerStateDidChange:)
+                                                               name:NSProcessInfoPowerStateDidChangeNotification
+                                                             object:nil];
+                }
 
-            strongSelf.timerManager = [[MMETimerManager alloc]
-                initWithTimeInterval:NSUserDefaults.mme_configuration.mme_eventFlushInterval
-                target:strongSelf
-                selector:@selector(flush)];
-        };
+                strongSelf.paused = YES;
+                strongSelf.locationManager = [[MMELocationManager alloc] init];
+                strongSelf.locationManager.delegate = strongSelf;
+                [strongSelf resumeMetricsCollection];
 
-        [self.dispatchManager scheduleBlock:initialization afterDelay:NSUserDefaults.mme_configuration.mme_startupDelay];
-    }
-    @catch(NSException *except) {
-        [self reportException:except];
-    }
+                strongSelf.timerManager = [[MMETimerManager alloc]
+                                           initWithTimeInterval:NSUserDefaults.mme_configuration.mme_eventFlushInterval
+                                           target:strongSelf
+                                           selector:@selector(flush)];
+            };
+
+            [self.dispatchManager scheduleBlock:initialization afterDelay:NSUserDefaults.mme_configuration.mme_startupDelay];
+        }
+        @catch(NSException *except) {
+            [self reportException:except];
+        }
 }
 
 #pragma mark - Enable/Disable

--- a/Tests/Integration/Startup/.gitignore
+++ b/Tests/Integration/Startup/.gitignore
@@ -1,0 +1,5 @@
+*.xcodeproj
+*.xcworkspace
+Pods/
+Podfile.lock
+

--- a/Tests/Integration/Startup/Podfile
+++ b/Tests/Integration/Startup/Podfile
@@ -1,0 +1,25 @@
+platform :ios, '13.0'
+inhibit_all_warnings!
+use_frameworks!
+
+def shared_pods
+  pod 'MapboxMobileEvents', :path => '../../../'
+  pod 'MapboxAccounts'
+  pod 'MapboxCommon'
+  pod 'MapboxDirections'
+  pod 'MapboxGeocoder.swift'
+  pod 'MapboxSpeech'
+  pod 'MapboxStatic.swift'
+  pod 'Fingertips'
+  pod 'Turf'
+  pod 'Alamofire'
+  pod 'SwiftyJSON'
+  pod 'FacebookSDK'
+end
+
+target 'PodInstall' do
+  shared_pods
+  target 'PodInstallTests' do
+    inherit! :search_paths
+  end
+end

--- a/Tests/Integration/Startup/Sources/AppDelegate.swift
+++ b/Tests/Integration/Startup/Sources/AppDelegate.swift
@@ -1,0 +1,31 @@
+import UIKit
+import MapboxMobileEvents
+import os.log
+import os.signpost
+
+
+struct SignpostLog {
+    static var initTime = OSLog(subsystem: "com.mapbox.MME", category: "INIT")
+}
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate, MMEEventsManagerDelegate {
+    var window: UIWindow?
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+
+        os_signpost(.begin, log: SignpostLog.initTime, name: "INIT")
+        MMEEventsManager.shared().initialize(withAccessToken: "foo", userAgentBase: "bar", hostSDKVersion: "1.0.0")
+        os_signpost(.end, log: SignpostLog.initTime, name: "INIT")
+
+
+        let viewController = UIViewController()
+        viewController.view.backgroundColor = .red
+        self.window = UIWindow(frame: UIScreen.main.bounds)
+
+        self.window?.rootViewController = viewController
+        self.window?.makeKeyAndVisible()
+
+        return true
+    }
+}

--- a/Tests/Integration/Startup/Sources/AppDelegate.swift
+++ b/Tests/Integration/Startup/Sources/AppDelegate.swift
@@ -13,18 +13,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate, MMEEventsManagerDelegate 
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-
-        os_signpost(.begin, log: SignpostLog.initTime, name: "INIT")
-        MMEEventsManager.shared().initialize(withAccessToken: "foo", userAgentBase: "bar", hostSDKVersion: "1.0.0")
-        os_signpost(.end, log: SignpostLog.initTime, name: "INIT")
-
-
         let viewController = UIViewController()
         viewController.view.backgroundColor = .red
         self.window = UIWindow(frame: UIScreen.main.bounds)
 
         self.window?.rootViewController = viewController
         self.window?.makeKeyAndVisible()
+
+        os_signpost(.begin, log: SignpostLog.initTime, name: "INIT")
+        MMEEventsManager.shared().initialize(withAccessToken: "foo", userAgentBase: "bar", hostSDKVersion: "1.0.0")
+        os_signpost(.end, log: SignpostLog.initTime, name: "INIT")
 
         return true
     }

--- a/Tests/Integration/Startup/Sources/Info.plist
+++ b/Tests/Integration/Startup/Sources/Info.plist
@@ -1,0 +1,1 @@
+../../Sources/Info.plist

--- a/Tests/Integration/Startup/Tests/Info.plist
+++ b/Tests/Integration/Startup/Tests/Info.plist
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.0.2</string>
+	<key>CFBundleSignature</key>
+	<string>MBGL</string>
+	<key>CFBundleVersion</key>
+	<string>7877</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>MGLMapboxAccessToken</key>
+	<string>$(MAPBOX_ACCESS_TOKEN)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>© 2014–2019 Mapbox</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>The map will display your location. If you choose Always, the map may also use your location when it isn’t visible in order to improve OpenStreetMap and Mapbox products.</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>The map will display your location. The map may also use your location when it isn’t visible in order to improve OpenStreetMap and Mapbox products.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>The map will display your location.</string>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Tests/Integration/Startup/Tests/StartupTests.swift
+++ b/Tests/Integration/Startup/Tests/StartupTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+import MapboxMobileEvents
+
+class StartupTests: XCTestCase {
+
+    func testInitPerformance() {
+        self.measure(metrics: [XCTCPUMetric.init()]) {
+            MMEEventsManager.shared().initialize(withAccessToken: "foo", userAgentBase: "bar", hostSDKVersion: "1.0.0")
+        }
+    }
+}

--- a/Tests/Integration/Startup/project.yml
+++ b/Tests/Integration/Startup/project.yml
@@ -1,0 +1,23 @@
+name: PodInstall
+options:
+  bundleIdPrefix: com.mapbox.common.events.PodInstall
+targets:
+  PodInstall:
+    type: application
+    platform: iOS
+    deploymentTarget: "13.0"
+    sources: [Sources]
+    settings:
+      DEVELOPMENT_TEAM: "GJZR2MEM28"
+      SUPPORTS_MACCATALYST: YES
+      DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER: YES
+  PodInstallTests:
+    type: bundle.unit-test
+    platform: iOS
+    deploymentTarget: "13.0"
+    sources:
+      - path: Tests
+    dependencies:
+      - target: PodInstall
+    settings:
+        DEVELOPMENT_TEAM: "GJZR2MEM28"

--- a/Tests/MMEAPIConfigTests.m
+++ b/Tests/MMEAPIConfigTests.m
@@ -53,9 +53,25 @@
 
     NSError *configError = nil;
     MMEServiceFixture *configFixture = [MMEServiceFixture serviceFixtureWithResource:@"config-null"];
-    
     [self.apiClient startGettingConfigUpdates];
-    XCTAssert(self.apiClient.isGettingConfigUpdates);
+
+    XCTestExpectation *expectation = nil;
+    expectation = [self expectationWithDescription:@"apiClient should be getting config updates"];
+
+    dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+    dispatch_async(queue, ^{
+        for (int i=0; i<50; i++) {
+            if (self.apiClient.isGettingConfigUpdates) {
+                [expectation fulfill];
+                break;
+            } else {
+                [NSThread sleepForTimeInterval:0.1];
+            }
+        }
+    });
+
+    [self waitForExpectations:@[expectation] timeout:5];
+
     XCTAssert([configFixture waitForConnectionWithTimeout:MME10sTimeout error:&configError]);
     XCTAssertNil(configError);
 }


### PR DESCRIPTION
Dispatch to a global queue with default priority when calling `-[MMEAPIClient requestForConfiguration]`

Using 12 assorted dependencies
<details><summary>Dependencies</summary>

```bash
MapboxMobileEvents
MapboxAccounts
MapboxCommon
MapboxDirections
MapboxGeocoder.swift
MapboxSpeech
MapboxStatic.swift
Fingertips
Turf
Alamofire
SwiftyJSON
FacebookSDK
```

</details>

indicated that initializing the MMEEventManager and MMEAPIClient spent ~100ms on the main thread and with this change, we spend ~3ms on the main thread.

Before
<img src="https://user-images.githubusercontent.com/764476/92461413-8dec1000-f1c9-11ea-8393-5c9f1e405127.png" width=300>

After
<img src="https://user-images.githubusercontent.com/764476/92461445-93e1f100-f1c9-11ea-9e38-53ce1b21b023.png" width=300>

cc @alfwatt @nagineni @mr1sunshine 