### PR TITLE
Replace @module import with #import for Obj-C++ client support

### DIFF
--- a/MapboxMobileEvents/Categories/NSUserDefaults+MMEConfiguration.h
+++ b/MapboxMobileEvents/Categories/NSUserDefaults+MMEConfiguration.h
@@ -1,6 +1,6 @@
 
-@import Foundation;
-@import CoreLocation;
+#import <Foundation/Foundation.h>
+#import <CoreLocation/CoreLocation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
When using MapboxEvents in combination with an Objective-C++ class, you will get the following error:

```
Use of @import when modules are disabled
```

This is due to the `@import` statement inside the framework's exposed `NSUserDefaults+MMEConfiguration.h` header. Changing it to the traditional angle bracket import fixes the issue.