### PR TITLE
[events] Send digest header value to the location event

### DIFF
--- a/MapboxMobileEvents/Categories/NSUserDefaults+MMEConfiguration.m
+++ b/MapboxMobileEvents/Categories/NSUserDefaults+MMEConfiguration.m
@@ -215,6 +215,14 @@ NS_ASSUME_NONNULL_BEGIN
     return clientId;
 }
 
+- (nullable NSString *)mme_configDigestValue {
+    return (NSString *)[self stringForKey:MMEConfigDigestHeaderValue];
+}
+
+- (void)mme_setConfigDigestValue:(nullable NSString *)digestHeader {
+    [self mme_setObject:digestHeader forPersistentKey:MMEConfigDigestHeaderValue];
+}
+
 // MARK: - Service Configuration
 
 - (BOOL)mme_isCNRegion {

--- a/MapboxMobileEvents/Categories/NSUserDefaults+MMEConfiguration_Private.h
+++ b/MapboxMobileEvents/Categories/NSUserDefaults+MMEConfiguration_Private.h
@@ -25,6 +25,7 @@ static MMEPersistentKey * const MMEHorizontalAccuracy = @"MMEHorizontalAccuracy"
 static MMEPersistentKey * const MMECertificateRevocationList = @"MMECertificateRevocationList";
 static MMEPersistentKey * const MMEConfigEventTag = @"MMEConfigEventTag";
 static MMEPersistentKey * const MMEConfigUpdateData = @"MMEConfigUpdateData";
+static MMEPersistentKey * const MMEConfigDigestHeaderValue = @"MMEConfigDigestHeaderValue";
 
 // MARK: - MMEConfigurationVolatileDomain
 
@@ -103,6 +104,7 @@ static NSTimeInterval const MMEStartupDelayMaximum = 100;
 
 @interface NSUserDefaults (MMEConfiguration_Private)
 @property(nonatomic,readonly) NSString *mme_clientId;
+@property (nonatomic, nullable, setter=mme_setConfigDigestValue:) NSString *mme_configDigestValue;
 
 + (void)mme_resetConfiguration;
 

--- a/MapboxMobileEvents/MMEAPIClient.h
+++ b/MapboxMobileEvents/MMEAPIClient.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)postEvents:(NSArray *)events completionHandler:(nullable void (^)(NSError * _Nullable error))completionHandler;
 - (void)postEvent:(MMEEvent *)event completionHandler:(nullable void (^)(NSError * _Nullable error))completionHandler;
 - (void)postMetadata:(NSArray *)metadata filePaths:(NSArray *)filePaths completionHandler:(nullable void (^)(NSError * _Nullable error))completionHandler;
++ (nullable NSString *)parseDigestHeader:(NSString *)digestHeader;
 
 // MARK: - Configuration Service
 

--- a/MapboxMobileEvents/MMEConstants.h
+++ b/MapboxMobileEvents/MMEConstants.h
@@ -61,6 +61,7 @@ extern NSString * const MMEEventKeyFloor;
 extern NSString * const MMEEventKeyVendorId;
 extern NSString * const MMEEventKeyModel;
 extern NSString * const MMEEventKeyDevice;
+extern NSString * const MMEEventKeyConfig;
 extern NSString * const MMEEventKeySkuId;
 extern NSString * const MMEEventKeyEnabledTelemetry;
 extern NSString * const MMEEventKeyOperatingSystem;

--- a/MapboxMobileEvents/MMEConstants.m
+++ b/MapboxMobileEvents/MMEConstants.m
@@ -66,6 +66,7 @@ NSString * const MMEEventKeyCreated = @"created";
 NSString * const MMEEventKeyVendorId = @"userId";
 NSString * const MMEEventKeyModel = @"model";
 NSString * const MMEEventKeyDevice = @"device";
+NSString * const MMEEventKeyConfig = @"config";
 NSString * const MMEEventKeySkuId = @"skuId";
 NSString * const MMEEventKeyEnabledTelemetry = @"enabled.telemetry";
 NSString * const MMEEventKeyOperatingSystem = @"operatingSystem";

--- a/MapboxMobileEvents/MMEEventsManager.m
+++ b/MapboxMobileEvents/MMEEventsManager.m
@@ -27,6 +27,7 @@
 #import "CLLocation+MMEMobileEvents.h"
 #import "CLLocationManager+MMEMobileEvents.h"
 #import "NSUserDefaults+MMEConfiguration.h"
+#import "NSUserDefaults+MMEConfiguration_Private.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -605,6 +606,13 @@ NS_ASSUME_NONNULL_BEGIN
             MMEEventKeySpeed: @([location mme_roundedSpeed]),
             MMEEventKeyCourse: @([location mme_roundedCourse])
         }];
+
+        NSString *digest = NSUserDefaults.mme_configuration.mme_configDigestValue;
+        if (digest) {
+            [eventAttributes addEntriesFromDictionary:@{
+                MMEEventKeyConfig: digest
+            }];
+        }
         
         if (@available(iOS 13.4, *)) {
             [eventAttributes addEntriesFromDictionary:@{

--- a/Tests/MMEAPIClientTests.m
+++ b/Tests/MMEAPIClientTests.m
@@ -142,4 +142,19 @@
     XCTAssert(data.mme_gunzippedData.length == uncompressedData.length);
 }
 
+- (void)testDigestHeaderParser {
+    [MMEAPIClient parseDigestHeader:@"test"];
+
+    // Fallback to the value received from the config service assuming that the Digest: header comes from a 1.0 config service has just a hash value.
+    XCTAssert([[MMEAPIClient parseDigestHeader:@"IEU/qC6Su+rB4L46hheNt9cDd4lyNBlCEU9ZADl38rg="] isEqualToString:@"IEU/qC6Su+rB4L46hheNt9cDd4lyNBlCEU9ZADl38rg="]);
+    // Expect the hash for SHA-256
+    XCTAssert([[MMEAPIClient parseDigestHeader:@"SHA-256=IEU/qC6Su+rB4L46hheNt9cDd4lyNBlCEU9ZADl38rg="] isEqualToString:@"IEU/qC6Su+rB4L46hheNt9cDd4lyNBlCEU9ZADl38rg="]);
+    // Expect the hash for SHA-256
+    XCTAssert([[MMEAPIClient parseDigestHeader:@"SHA-512=EU/qC6,SHA-256=CEU9ZADl38rg"] isEqualToString:@"CEU9ZADl38rg"]);
+    // null in case of no SHA-256 hash
+    XCTAssertNil([MMEAPIClient parseDigestHeader:@"SHA-512=EU/qC6,SHA-2=CEU9ZADl38rg"]);
+    // null in case of no SHA-256 hash
+    XCTAssertNil([MMEAPIClient parseDigestHeader:@"SHA-512=EU/qC6,SHA-2=CEU9ZADl38rg,IEU/qC6Su+rB4L46hheNt9cDd4lyNBlCEU9ZADl38rg="]);
+}
+
 @end

--- a/Tests/NSUserDefaults+MMEConfigurationTests.m
+++ b/Tests/NSUserDefaults+MMEConfigurationTests.m
@@ -33,6 +33,7 @@
         MMECollectionEnabledInSimulator: @YES,
         MMECollectionDisabledInBackground: @YES,
         MMEConfigEventTag: @"tag",
+        MMEConfigDigestHeaderValue: @"Dd4lyNBlCEU9ZADl38rg=",
         MMECertificateRevocationList:@[
             @"T4XyKSRwZ5icOqGmJUXiDYGa+SaXKTGQXZwhqpwNTEo=",
             @"KlV7emqpeM6V2MtDEzSDzcIob6VwkdWHiVsNQQzTIeo="]
@@ -88,6 +89,10 @@
 
 - (void)testConfigEventTagDefault {
     XCTAssert([NSUserDefaults.mme_configuration.mme_eventTag isEqual:@"tag"]);
+}
+
+- (void)testConfigDigestValueDefault {
+    XCTAssert([NSUserDefaults.mme_configuration.mme_configDigestValue isEqual:@"Dd4lyNBlCEU9ZADl38rg="]);
 }
 
 // MARK: - Client Id Tests
@@ -503,6 +508,11 @@
     MMEDate *date = [NSUserDefaults.mme_configuration mme_configUpdateDate];
     
     XCTAssert(date);
+}
+
+- (void)testConfigDigestChange {
+    [NSUserDefaults.mme_configuration mme_setConfigDigestValue:@"IEU/qC6Su+rB4L46hheNt9cDd4lyNBlCEU9ZADl38rg="];
+    XCTAssert([NSUserDefaults.mme_configuration.mme_configDigestValue isEqualToString:@"IEU/qC6Su+rB4L46hheNt9cDd4lyNBlCEU9ZADl38rg="]);
 }
 
 @end


### PR DESCRIPTION
Send digest header value to location events in order to relate events which were generated with various configurations.