### PR TITLE
v0.10.4-alpha.1

### DIFF
--- a/MapboxMobileEvents.podspec
+++ b/MapboxMobileEvents.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.name = 'MapboxMobileEvents'
-  s.version = "0.10.3"
+  s.version = "0.10.4-alpha.1"
   s.summary = "Mapbox Mobile Events"
 
   s.description  = "Collects usage information to help Mapbox improve its products."

--- a/MapboxMobileEvents/Info.plist
+++ b/MapboxMobileEvents/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.10.3</string>
+	<string>0.10.4-alpha.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-events-ios",
-  "version": "0.10.3",
+  "version": "0.10.4-alpha.1",
   "description": "Telemetry and Location Services",
   "keywords": [
     "mapbox",


### PR DESCRIPTION
- Adds Cocoapods integration testing
- Adds tests to measure startup time
- Fixes headers for Objective-C++ Clients (Thanks to Damiaan Twelker)
- Adds support for reporting reduced accuracy on iOS 14 devices
- Adds configuration option for setting the horizontal accuracy
- Adds counters to our stats object to track various location states