### PR TITLE
Add iOS SDK version check

### DIFF
--- a/Sources/MapboxMobileEvents/CLLocation+MMEMobileEvents.h
+++ b/Sources/MapboxMobileEvents/CLLocation+MMEMobileEvents.h
@@ -12,8 +12,6 @@ void mme_linkCLLocationCategory();
 - (CLLocationDistance)mme_roundedAltitude;
 - (CLLocationAccuracy)mme_roundedHorizontalAccuracy;
 - (CLLocationAccuracy)mme_roundedVerticalAccuracy;
-- (CLLocationAccuracy)mme_roundedSpeedAccuracy API_AVAILABLE(ios(13.4));
-- (CLLocationAccuracy)mme_roundedCourseAccuracy API_AVAILABLE(ios(13.4));
 - (CLLocationDegrees)mme_latitudeRoundedWithPrecision:(NSUInteger)precision;
 - (CLLocationDegrees)mme_longitudeRoundedWithPrecision:(NSUInteger)precision;
 

--- a/Sources/MapboxMobileEvents/CLLocation+MMEMobileEvents.m
+++ b/Sources/MapboxMobileEvents/CLLocation+MMEMobileEvents.m
@@ -24,22 +24,6 @@ void mme_linkCLLocationCategory(){}
     return round(self.verticalAccuracy);
 }
 
-- (CLLocationAccuracy)mme_roundedSpeedAccuracy {
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130400
-    return round(self.speedAccuracy);
-#else
-    return -1.0;
-#endif
-}
-
-- (CLLocationAccuracy)mme_roundedCourseAccuracy {
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130400
-    return round(self.courseAccuracy);
-#else
-    return -1.0;
-#endif
-}
-
 - (CLLocationDegrees)mme_latitudeRoundedWithPrecision:(NSUInteger)precision {
     return [self mme_value:self.coordinate.latitude withPrecision:precision];
 }

--- a/Sources/MapboxMobileEvents/CLLocation+MMEMobileEvents.m
+++ b/Sources/MapboxMobileEvents/CLLocation+MMEMobileEvents.m
@@ -25,11 +25,19 @@ void mme_linkCLLocationCategory(){}
 }
 
 - (CLLocationAccuracy)mme_roundedSpeedAccuracy {
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130400
     return round(self.speedAccuracy);
+#else
+    return -1.0;
+#endif
 }
 
 - (CLLocationAccuracy)mme_roundedCourseAccuracy {
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130400
     return round(self.courseAccuracy);
+#else
+    return -1.0;
+#endif
 }
 
 - (CLLocationDegrees)mme_latitudeRoundedWithPrecision:(NSUInteger)precision {

--- a/Sources/MapboxMobileEvents/MMEEventsManager.m
+++ b/Sources/MapboxMobileEvents/MMEEventsManager.m
@@ -623,12 +623,14 @@ NS_ASSUME_NONNULL_BEGIN
             }];
         }
         
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130400
         if (@available(iOS 13.4, *)) {
             [eventAttributes addEntriesFromDictionary:@{
                 MMEEventKeySpeedAccuracy: @([location speedAccuracy]),
                 MMEEventKeyCourseAccuracy: @([location courseAccuracy])
             }];
         }
+#endif
 
         if ([self.locationManager isReducedAccuracy]) {
             [eventAttributes addEntriesFromDictionary:@{


### PR DESCRIPTION
~Fixes https://github.com/mapbox/mapbox-events-ios/issues/236 by adding compile time checks for the iOS 13.4 SDK (introduced in Xcode 11.4).~

Fixes #236 by removing unused code and adding compile time checks for the iOS 13.4 SDK

cc @alfwatt 

