### PR TITLE
Fix group path

### DIFF
--- a/MapboxMobileEvents.xcodeproj/project.pbxproj
+++ b/MapboxMobileEvents.xcodeproj/project.pbxproj
@@ -465,7 +465,8 @@
 				35DD3D18250A4F7B00513CA7 /* UIKit+MMEMobileEvents.m */,
 				35DD3D74250A4FB400513CA7 /* Info.plist */,
 			);
-			path = MapboxMobileEvents;
+			name = MapboxMobileEvents;
+			path = Sources/MapboxMobileEvents;
 			sourceTree = "<group>";
 		};
 		35DD3DB6250A545D00513CA7 /* MapboxMobileEventsTests */ = {


### PR DESCRIPTION
Fixes bad reference to `MapboxMobileEvents` group

<img src="https://user-images.githubusercontent.com/764476/93348002-ff653780-f835-11ea-9120-d6098f5d36dd.png" width=200>


cc @mr1sunshine 