### PR TITLE
[src] Use lazy initializers for MMELocationManager and CLLocationManager

### DIFF
--- a/MapboxMobileEventsCedarTests/MMELocationManagerTests.mm
+++ b/MapboxMobileEventsCedarTests/MMELocationManagerTests.mm
@@ -299,7 +299,7 @@ describe(@"MMELocationManager", ^{
         });
         
         it(@"tells location manager to stop updating location", ^{
-            locationManager.locationManager should be_nil;
+            locationManager.isUpdatingLocation should be_falsy;
         });
         
         it(@"tells the location manager to stopMonitoringSignificantLocationChanges", ^{

--- a/Sources/MapboxMobileEvents/MMEEventsManager.m
+++ b/Sources/MapboxMobileEvents/MMEEventsManager.m
@@ -126,7 +126,6 @@ NS_ASSUME_NONNULL_BEGIN
                 }
 
                 strongSelf.paused = YES;
-                strongSelf.locationManager = [[MMELocationManager alloc] init];
                 strongSelf.locationManager.delegate = strongSelf;
                 [strongSelf resumeMetricsCollection];
 
@@ -570,6 +569,16 @@ NS_ASSUME_NONNULL_BEGIN
     if (self.eventQueue.count == 1) {
         [self.timerManager start];
     }
+}
+
+- (id<MMELocationManager>) locationManager {
+    static dispatch_once_t onceToken;
+
+    dispatch_once(&onceToken, ^{
+        _locationManager = [[MMELocationManager alloc] init];
+    });
+
+    return _locationManager;
 }
 
 #pragma mark - MMELocationManagerDelegate

--- a/Sources/MapboxMobileEvents/MMELocationManager.m
+++ b/Sources/MapboxMobileEvents/MMELocationManager.m
@@ -31,8 +31,17 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
 
 @implementation MMELocationManager
 
+@synthesize locationManager = _locationManager;
+
 - (void)dealloc {
     _locationManager.delegate = nil;
+}
+
+- (CLLocationManager *)locationManager  {
+    if (_locationManager == nil) {
+        _locationManager = [[MMEDependencyManager sharedManager] locationManagerInstance];
+    }
+    return _locationManager;
 }
 
 - (instancetype)init {
@@ -53,7 +62,6 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
         return;
     }
 
-    self.locationManager = [[MMEDependencyManager sharedManager] locationManagerInstance];
     [self configurePassiveLocationManager];
     [self startLocationServices];
 }
@@ -68,7 +76,6 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
             [self.delegate locationManagerDidStopLocationUpdates:self];
         }
         [self stopMonitoringRegions];
-        self.locationManager = nil;
     }
 }
 
@@ -104,10 +111,14 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
 #endif
 
 - (void)setLocationManager:(CLLocationManager *)locationManager {
-    id<CLLocationManagerDelegate> delegate = _locationManager.delegate;
-    _locationManager.delegate = nil;
-    _locationManager = locationManager;
-    _locationManager.delegate = delegate;
+    if (locationManager == nil) {
+        _locationManager = locationManager;
+    } else {
+        id<CLLocationManagerDelegate> delegate = _locationManager.delegate;
+        _locationManager.delegate = nil;
+        _locationManager = locationManager;
+        _locationManager.delegate = delegate;
+    }
 }
 
 - (void)stopMonitoringRegions {


### PR DESCRIPTION
Starting from iOS14 in order to get locationAuthorization(and
accuracyAutorization) we need to call instance methods of
CLLocationManager. Since it is possible for SDKs to send userTurnstile
event before finishing construction of MMEEventManager (we have
`initializtion` callback in `initializeWithAccessToken`) we might end up
in situation when CCLocationManager is not created yet.

To avoid behaviour above we introduce two lazy initializers for:
- MMELocationManager in MMEEventManager
- CCLocationManager in MMELocationManager
so both location managers will be always available whenver we try to
access to them.

After this change there is no need to set CCLocationManager pointer to
nil when we call `stopUpdatingLocation` since location manager now is
always available.