### PR TITLE
Run pod lib lint on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,9 @@ jobs:
           command: xcodebuild -project MapboxMobileEvents.xcodeproj -scheme MMETestHost build test -destination 'platform=iOS Simulator,name=iPhone 11,OS=latest' GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES
       - run:
           name: Test CocoaPods
-          command: Tests/Integration/test_cocoapods.sh
+          command: |
+            pod lib lint MapboxMobileEvents.podspec
+            Tests/Integration/test_cocoapods.sh
       - run:
           name: Test Carthage
           command: |

--- a/MapboxMobileEvents.podspec
+++ b/MapboxMobileEvents.podspec
@@ -31,8 +31,6 @@ Pod::Spec.new do |s|
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.source_files = ["Sources/MapboxMobileEvents/**/*.{h,m}"]
-  s.resources = "Sources/MapboxMobileEvents/Resources/*"
-  s.exclude_files = "Sources/MapboxMobileEvents/MMENamespacedDependencies.h"
 
   # ――― Project Settings ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 


### PR DESCRIPTION
Fixes 
```
$ pod lib lint MapboxMobileEvents.podspec
- ERROR | [iOS] file patterns: The `resources` pattern did not match any file.
```

I removed the resources entry since we no longer provide any resources.
I also removed the exclusion of `MMENamespacedDependencies.h` which is no longer part of this repo since we removed the static lib `libMapboxMobileEvents` which no longer is being used by gl-native.

cc @nagineni @mr1sunshine @alfwatt @1ec5 