### PR TITLE
Improve the comparison with the bundle id

### DIFF
--- a/Sources/MapboxMobileEvents/NSUserDefaults+MMEConfiguration.m
+++ b/Sources/MapboxMobileEvents/NSUserDefaults+MMEConfiguration.m
@@ -320,9 +320,8 @@ NS_ASSUME_NONNULL_BEGIN
         // check all loaded frameworks for mapbox frameworks, record their bundleIdentifier
         NSMutableSet *loadedMapboxBundleIds = NSMutableSet.new;
         for (NSBundle *loaded in [NSBundle.allFrameworks arrayByAddingObjectsFromArray:NSBundle.allBundles]) {
-            if (loaded.bundleIdentifier
-             && loaded.bundleIdentifier != NSBundle.mme_mainBundle.bundleIdentifier
-             && [loaded.bundleIdentifier rangeOfString:@"mapbox" options:NSCaseInsensitiveSearch].location != NSNotFound) {
+            if ([loaded.bundleIdentifier hasPrefix:@"com.mapbox"]
+                && loaded.bundleIdentifier != NSBundle.mme_mainBundle.bundleIdentifier) {
                 [loadedMapboxBundleIds addObject:loaded.bundleIdentifier];
             }
         }


### PR DESCRIPTION
This is a change to improve the speed of user agent generation.

- Objective-C does not crash if the receiver is `nil`, and returns `false`, so nil checking can be reduced.
- Forward matching is faster for string comparisons. The bundle ID string of the mapbox SDK starts with `com.mapbox`. 

If there is a problem with the implementation, let me know. 😃 