### PR TITLE
Add 5 new pins for the staging endpoint

### DIFF
--- a/Sources/MapboxMobileEvents/NSUserDefaults+MMEConfiguration.m
+++ b/Sources/MapboxMobileEvents/NSUserDefaults+MMEConfiguration.m
@@ -496,7 +496,15 @@ NS_ASSUME_NONNULL_BEGIN
         MMEEventsMapboxCom: comPublicKeys,
         MMEEventsMapboxCN: cnPublicKeys,
 #if DEBUG
-        MMEEventsTilestreamNet: @[@"f0eq9TvzcjRVgNZjisBA1sVrQ9b0pJA5ESWg6hVpK2c="]
+        MMEEventsTilestreamNet: @[
+            @"f0eq9TvzcjRVgNZjisBA1sVrQ9b0pJA5ESWg6hVpK2c=",
+            // new 2048 bit staging keys generated in April 2021
+            @"8apXPecP7X3vUGqi/B42cig4O1BjQUM4dng5gMVOiK0=",
+            @"MxGjtNVZ0mEdjhhfvAcTNZd+lC8WY8vKkkaSFE2azXQ=",
+            @"i/5fi5jB13JKeiZJMFNu4XSIaaCNmxAWsWvmMsI7t5s=",
+            @"4YJLMcE66WP2/FRID2HT0QpQRNjG7zqz/dJzP3BGct8=",
+            @"H1YTKuZacKUYyGnQFVPcarkqYxvGJ7QKb9dFz2TssKw="
+        ]
 #endif
     };
 }


### PR DESCRIPTION
Adding 5 new staging pins for 2048 bit keys.

In parallel with the corresponding ticket for [mapbox-events-android](https://github.com/mapbox/mapbox-events-android/pull/519).
Part of [certificate rotation](https://github.com/mapbox/api-events/issues/701)