### PR TITLE
Support arm64 iOS Simulator, Catalyst and dSyms in XCFramework

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ workflows:
             tags:
               only: /.*/
       - prepare_release:
-         xcode: "12.0.0"
+         xcode: "12.2.0"
 
 jobs:
   build:

--- a/MapboxMobileEvents.xcodeproj/project.pbxproj
+++ b/MapboxMobileEvents.xcodeproj/project.pbxproj
@@ -1329,11 +1329,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 20;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				EXCLUDED_ARCHS = "$(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))";
-				EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = "arm64 arm64e armv7 armv7s armv6 armv8";
-				HEADER_SEARCH_PATHS = "$(SRCROOT)/vendor/TrustKit/TrustKit/**";
 				INFOPLIST_FILE = Sources/MapboxMobileEvents/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LLVM_LTO = NO;
 				OTHER_LDFLAGS = "-lz";
@@ -1341,7 +1337,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
-				SUPPORTS_MACCATALYST = YES;
 				WARNING_CFLAGS = (
 					"-Wunused-property-ivar",
 					"-Wsemicolon-before-method-body",
@@ -1362,11 +1357,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 20;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				EXCLUDED_ARCHS = "$(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))";
-				EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = "arm64 arm64e armv7 armv7s armv6 armv8";
-				HEADER_SEARCH_PATHS = "$(SRCROOT)/vendor/TrustKit/TrustKit/**";
 				INFOPLIST_FILE = Sources/MapboxMobileEvents/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LLVM_LTO = YES;
 				OTHER_LDFLAGS = "-lz";
@@ -1374,7 +1365,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
-				SUPPORTS_MACCATALYST = YES;
 				WARNING_CFLAGS = (
 					"-Wunused-property-ivar",
 					"-Wsemicolon-before-method-body",

--- a/scripts/prepare_release_artifacts.sh
+++ b/scripts/prepare_release_artifacts.sh
@@ -13,8 +13,8 @@ rm -rf $ROOT_DIR/build/artifacts
 
 # build iOS .frameworks
 xcodebuild archive \
-        -archivePath ${ROOT_DIR}/build/artifacts/frameworks/iOS \
-        -project ${ROOT_DIR}/MapboxMobileEvents.xcodeproj \
+        -archivePath "${ROOT_DIR}/build/artifacts/frameworks/iOS" \
+        -project "${ROOT_DIR}/MapboxMobileEvents.xcodeproj" \
         -scheme MapboxMobileEvents \
         -destination "generic/platform=iOS"\
         BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
@@ -22,8 +22,8 @@ xcodebuild archive \
 
 # build Catalyst .framework
 xcodebuild archive \
-        -archivePath ${ROOT_DIR}/build/artifacts/frameworks/iOS-Catalyst \
-        -project ${ROOT_DIR}/MapboxMobileEvents.xcodeproj \
+        -archivePath "${ROOT_DIR}/build/artifacts/frameworks/iOS-Catalyst" \
+        -project "${ROOT_DIR}/MapboxMobileEvents.xcodeproj" \
         -scheme MapboxMobileEvents \
         -destination "platform=macOS,variant=Mac Catalyst" \
         BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
@@ -31,8 +31,8 @@ xcodebuild archive \
 
 # build iOS Simulator .framework
 xcodebuild archive \
-        -archivePath ${ROOT_DIR}/build/artifacts/frameworks/iOS-Simulator \
-        -project ${ROOT_DIR}/MapboxMobileEvents.xcodeproj \
+        -archivePath "${ROOT_DIR}/build/artifacts/frameworks/iOS-Simulator" \
+        -project "${ROOT_DIR}/MapboxMobileEvents.xcodeproj" \
         -scheme MapboxMobileEvents \
         -destination "generic/platform=iOS Simulator" \
         BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
@@ -50,8 +50,8 @@ xcodebuild \
     -output "${ROOT_DIR}/build/artifacts/frameworks/MapboxMobileEvents.xcframework"
 
 # zip artifacts
-mkdir -p ${ROOT_DIR}/build/artifacts/zip
-ZIPDIR=${ROOT_DIR}/build/artifacts/zip
+mkdir -p "${ROOT_DIR}/build/artifacts/zip"
+ZIPDIR="${ROOT_DIR}/build/artifacts/zip"
 
 pushd ${ROOT_DIR}/build/artifacts/frameworks/iOS.xcarchive/Products/Library/Frameworks
 zip --symlinks -r "${ZIPDIR}/MapboxMobileEvents-ios.zip" MapboxMobileEvents.framework

--- a/scripts/prepare_release_artifacts.sh
+++ b/scripts/prepare_release_artifacts.sh
@@ -16,44 +16,27 @@ xcodebuild archive \
         -archivePath ${ROOT_DIR}/build/artifacts/frameworks/iOS \
         -project ${ROOT_DIR}/MapboxMobileEvents.xcodeproj \
         -scheme MapboxMobileEvents \
-        -destination="iOS" \
-        -sdk iphoneos \
-        -UseModernBuildSystem=YES \
-        -derivedDataPath ${ROOT_DIR}/build/derivedDataPath/iOS \
-        ONLY_ACTIVE_ARCH=NO \
+        -destination "generic/platform=iOS"\
         BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
-        SKIP_INSTALL=NO \
-        SUPPORTS_MACCATALYST=NO \
-        -configuration Release
+        SKIP_INSTALL=NO
 
 # build Catalyst .framework
 xcodebuild archive \
         -archivePath ${ROOT_DIR}/build/artifacts/frameworks/iOS-Catalyst \
         -project ${ROOT_DIR}/MapboxMobileEvents.xcodeproj \
         -scheme MapboxMobileEvents \
-        -destination="iOS" \
-        -UseModernBuildSystem=YES \
-        -derivedDataPath ${ROOT_DIR}/build/derivedDataPath/iOS-Catalyst \
-        ONLY_ACTIVE_ARCH=NO \
+        -destination "platform=macOS,variant=Mac Catalyst" \
         BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
-        SKIP_INSTALL=NO \
-        SUPPORTS_MACCATALYST=YES \
-        -configuration Release
+        SKIP_INSTALL=NO
 
 # build iOS Simulator .framework
 xcodebuild archive \
         -archivePath ${ROOT_DIR}/build/artifacts/frameworks/iOS-Simulator \
         -project ${ROOT_DIR}/MapboxMobileEvents.xcodeproj \
         -scheme MapboxMobileEvents \
-        -destination="iOS Simulator" \
-        -sdk iphonesimulator \
-        -UseModernBuildSystem=YES \
-        -derivedDataPath ${ROOT_DIR}/build/derivedDataPath/iOS-Simulator \
-        ONLY_ACTIVE_ARCH=NO \
+        -destination "generic/platform=iOS Simulator" \
         BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
-        SKIP_INSTALL=NO \
-        SUPPORTS_MACCATALYST=YES \
-        -configuration Release
+        SKIP_INSTALL=NO
 
 # build .xcframework
 xcodebuild \

--- a/scripts/prepare_release_artifacts.sh
+++ b/scripts/prepare_release_artifacts.sh
@@ -59,8 +59,11 @@ xcodebuild archive \
 xcodebuild \
     -create-xcframework \
     -framework "${ROOT_DIR}/build/artifacts/frameworks/iOS.xcarchive/Products/Library/Frameworks/MapboxMobileEvents.framework" \
+        -debug-symbols "${ROOT_DIR}/build/artifacts/frameworks/iOS.xcarchive/dSYMs/MapboxMobileEvents.framework.dSYM" \
     -framework "${ROOT_DIR}/build/artifacts/frameworks/iOS-Catalyst.xcarchive/Products/Library/Frameworks/MapboxMobileEvents.framework" \
+        -debug-symbols "${ROOT_DIR}/build/artifacts/frameworks/iOS-Catalyst.xcarchive/dSYMs/MapboxMobileEvents.framework.dSYM" \
     -framework "${ROOT_DIR}/build/artifacts/frameworks/iOS-Simulator.xcarchive/Products/Library/Frameworks/MapboxMobileEvents.framework" \
+        -debug-symbols "${ROOT_DIR}/build/artifacts/frameworks/iOS-Simulator.xcarchive/dSYMs/MapboxMobileEvents.framework.dSYM" \
     -output "${ROOT_DIR}/build/artifacts/frameworks/MapboxMobileEvents.xcframework"
 
 # zip artifacts

--- a/scripts/prepare_release_artifacts.sh
+++ b/scripts/prepare_release_artifacts.sh
@@ -68,9 +68,9 @@ mkdir -p ${ROOT_DIR}/build/artifacts/zip
 ZIPDIR=${ROOT_DIR}/build/artifacts/zip
 
 pushd ${ROOT_DIR}/build/artifacts/frameworks/iOS.xcarchive/Products/Library/Frameworks
-zip -r $ZIPDIR/MapboxMobileEvents.zip MapboxMobileEvents.framework
+zip --symlinks -r "${ZIPDIR}/MapboxMobileEvents-ios.zip" MapboxMobileEvents.framework
 popd
 
 pushd ${ROOT_DIR}/build/artifacts/frameworks
-zip -r $ZIPDIR/MapboxMobileEvents.xcframework.zip MapboxMobileEvents.xcframework
+zip --symlinks -r "${ZIPDIR}/MapboxMobileEvents.zip" MapboxMobileEvents.xcframework
 popd


### PR DESCRIPTION
* Add arm64 iOS Simulator slice
* Add arm64 macCatalyst slice
* Add dSyms to resulting XCFramework
* Preserve symlinks in archives (critical for macCatalyst slice)
* Drop superfluous and outdated build settings in Xcode project
* Simplified xcodebuild call to inherit the same default values