### PR TITLE
[build] Additional fixes for SDK registry deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,10 @@ workflows:
             tags:
               only: /.*/
       - prepare_release:
-         xcode: "12.2.0"
+          xcode: "12.2.0"
+          filters:
+            tags:
+              only: /.*/
 
 jobs:
   build:
@@ -26,29 +29,16 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Test SPM
-          command: |
-            # xcodebuild will try to use the Package manifest if it cannot find a project 
-            mkdir temp && mv MapboxMobileEvents.xcodeproj temp
-            xcodebuild -scheme MapboxMobileEvents test -destination "platform=iOS Simulator,name=iPhone 11,OS=latest"
-            mv temp/MapboxMobileEvents.xcodeproj . && rm -rf temp
+          name: Ensure netrc
+          command: Tests/Integration/ensure_netrc.sh
       - run:
           name: Test
           command: xcodebuild -project MapboxMobileEvents.xcodeproj -scheme MMETestHost build test -destination 'platform=iOS Simulator,name=iPhone 11,OS=latest' GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES
-      - run:
-          name: Test CocoaPods
-          command: |
-            pod lib lint MapboxMobileEvents.podspec
-            Tests/Integration/test_cocoapods.sh
       - run:
           name: Test Carthage
           command: |
             if [ "<< parameters.xcode >>" = "12.0.0" ]; then export XCODE_XCCONFIG_FILE=~/project/xcode-12-fix.xcconfig; fi
             Tests/Integration/test_carthage.sh
-      - run:
-          name: Test SPMXcode
-          command: |
-            Tests/Integration/test_spm_xcode.sh
   prepare_release:
     parameters:
       xcode:
@@ -58,8 +48,26 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Ensure netrc
+          command: Tests/Integration/ensure_netrc.sh
+      - run:
           name: Prepare release artifacts
           command: |
             scripts/prepare_release_artifacts.sh
+      - run:
+          name: Calculate checksum of Mapbox.zip
+          command: |
+              pushd build/artifacts/zip
+              swift package compute-checksum MapboxMobileEvents.zip > MapboxMobileEvents.zip.checksum
+              cat MapboxMobileEvents.zip.checksum
+              popd
+      - run:
+          name: Test CocoaPods
+          command: |
+            Tests/Integration/test_cocoapods.sh
+      - run:
+          name: Test SPMXcode
+          command: |
+            Tests/Integration/test_spm_xcode.sh
       - store_artifacts:
           path: build/artifacts/zip

--- a/MapboxMobileEvents.podspec
+++ b/MapboxMobileEvents.podspec
@@ -23,20 +23,16 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = "9.0"
 
-
   # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
-  s.source = { :git => "https://github.com/mapbox/mapbox-events-ios.git", :tag => "v#{s.version.to_s}" }
-
-  # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-
-  s.source_files = ["Sources/MapboxMobileEvents/**/*.{h,m}"]
+  s.source = {
+    :http => "https://api.mapbox.com/downloads/v2/mapbox-events-ios/releases/ios/packages/#{s.version.to_s}/MapboxMobileEvents.zip"
+  }
 
   # ――― Project Settings ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.requires_arc = true
-  s.module_name = 'MapboxMobileEvents'
-  s.library = 'z'
-  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
+  s.vendored_frameworks = 'MapboxMobileEvents.xcframework'
+  s.module_name = s.name
 
 end

--- a/Package.swift
+++ b/Package.swift
@@ -1,24 +1,24 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
+import Foundation
+
+let registry = SDKRegistry()
+let version = "1.0.1"
+let checksum = "fa540596a9991e9612219104d051dda1da4255e7985a0c6688ba4a3b81d1aee1"
 
 let package = Package(
     name: "MapboxMobileEvents",
-    platforms: [
-        .iOS(.v9)
-    ],
+    platforms: [.iOS(.v9)],
     products: [
         .library(
             name: "MapboxMobileEvents",
-            targets: ["MapboxMobileEvents"]),
+            targets: ["MapboxMobileEvents"]
+        )
     ],
-    dependencies: [],
     targets: [
-        .target(
-            name: "MapboxMobileEvents",
-            dependencies: []
-        ),
+        registry.mapboxEventsTarget(version: version, checksum: checksum),
         .testTarget(
             name: "MapboxMobileEventsTests",
             dependencies: ["MapboxMobileEvents"],
@@ -33,5 +33,125 @@ let package = Package(
             name: "MapboxMobileEventsSwiftTests",
             dependencies: ["MapboxMobileEvents"]
         ),
-    ]
+    ],
+    cxxLanguageStandard: .cxx14
 )
+
+struct SDKRegistry {
+    let host = "api.mapbox.com"
+
+    func binaryTarget(name: String, version: String, path: String, filename: String, checksum: String) -> Target {
+        var url = "https://\(host)/downloads/v2/\(path)/releases/ios/packages/\(version)/\(filename)"
+
+        if let token = netrcToken {
+            url += "?access_token=\(token)"
+        } else {
+            debugPrint("Mapbox token wasn't founded in ~/.netrc. Fix this issue to integrate Mapbox SDK. Otherwise, you will see 'invalid status code 401' or 'no XCFramework found. To clean issue in Xcode, remove ~/Library/Developer/Xcode/DerivedData folder")
+        }
+
+        return .binaryTarget(name: name, url: url, checksum: checksum)
+    }
+
+    var netrcToken: String? {
+        var mapboxToken: String?
+        do {
+            let netrc = try Netrc.load().get()
+            mapboxToken = netrc.machines.first(where: { $0.name == host })?.password
+        } catch {
+            // Do nothing on client machines
+        }
+
+        return mapboxToken
+    }
+}
+
+extension SDKRegistry {
+    func mapboxEventsTarget(version: String, checksum: String) -> Target {
+        return binaryTarget(name: "MapboxMobileEvents",
+                            version: version,
+                            path: "mapbox-events-ios",
+                            filename: "MapboxMobileEvents.zip",
+                            checksum: checksum)
+    }
+}
+
+// Reference: https://github.com/apple/swift-tools-support-core/pull/88
+// Sub-reference: https://github.com/Carthage/Carthage/pull/2774
+struct NetrcMachine {
+    let name: String
+    let login: String
+    let password: String
+}
+
+struct Netrc {
+
+    enum NetrcError: Error {
+        case fileNotFound(URL)
+        case unreadableFile(URL)
+        case machineNotFound
+        case missingToken(String)
+        case missingValueForToken(String)
+    }
+
+    public let machines: [NetrcMachine]
+
+    init(machines: [NetrcMachine]) {
+        self.machines = machines
+    }
+
+    static func load(from fileURL: URL = URL(fileURLWithPath: "\(NSHomeDirectory())/.netrc")) -> Result<Netrc, Error> {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else { return .failure(NetrcError.fileNotFound(fileURL)) }
+        guard FileManager.default.isReadableFile(atPath: fileURL.path) else { return .failure(NetrcError.unreadableFile(fileURL)) }
+
+        return Result(catching: { try String(contentsOf: fileURL, encoding: .utf8) })
+            .flatMap { Netrc.from($0) }
+    }
+
+    static func from(_ content: String) -> Result<Netrc, Error> {
+        let trimmedCommentsContent = trimComments(from: content)
+        let tokens = trimmedCommentsContent
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter({ $0 != "" })
+
+        var machines: [NetrcMachine] = []
+
+        let machineTokens = tokens.split { $0 == "machine" }
+        guard tokens.contains("machine"), machineTokens.count > 0 else { return .failure(NetrcError.machineNotFound) }
+
+        for machine in machineTokens {
+            let values = Array(machine)
+            guard let name = values.first else { continue }
+            guard let login = values["login"] else { return .failure(NetrcError.missingValueForToken("login")) }
+            guard let password = values["password"] else { return .failure(NetrcError.missingValueForToken("password")) }
+            machines.append(NetrcMachine(name: name, login: login, password: password))
+        }
+
+        guard machines.count > 0 else { return .failure(NetrcError.machineNotFound) }
+        return .success(Netrc(machines: machines))
+    }
+
+    private static func trimComments(from text: String) -> String {
+        let regex = try! NSRegularExpression(pattern: "\\#[\\s\\S]*?.*$", options: .anchorsMatchLines)
+        let nsString = text as NSString
+        let range = NSRange(location: 0, length: nsString.length)
+        let matches = regex.matches(in: text, range: range)
+        var trimmedCommentsText = text
+        matches.forEach {
+            trimmedCommentsText = trimmedCommentsText
+                .replacingOccurrences(of: nsString.substring(with: $0.range), with: "")
+        }
+        return trimmedCommentsText
+    }
+}
+
+fileprivate extension Array where Element == String {
+    subscript(_ token: String) -> String? {
+        guard let tokenIndex = firstIndex(of: token),
+            count > tokenIndex,
+            !["machine", "login", "password"].contains(self[tokenIndex + 1]) else {
+                return nil
+        }
+        return self[tokenIndex + 1]
+    }
+}

--- a/Tests/Integration/CocoaPods/Podfile
+++ b/Tests/Integration/CocoaPods/Podfile
@@ -1,5 +1,5 @@
 platform :ios, '9.0'
 
 target 'PodInstall' do
-  pod 'MapboxMobileEvents', :path => '../../../'
+  pod 'MapboxMobileEvents', :podspec => '../../../MapboxMobileEvents.podspec'
 end

--- a/Tests/Integration/ensure_netrc.sh
+++ b/Tests/Integration/ensure_netrc.sh
@@ -1,0 +1,13 @@
+HOMEDIR=~
+eval HOMEDIR=$HOMEDIR
+FILE="$HOMEDIR/.netrc"
+SDK_HOST="api.mapbox.com"
+
+if grep -q $SDK_HOST $FILE; then
+    echo "Entry for SDK Registry, not appending credentials."
+else
+    echo "machine api.mapbox.com" >> ~/.netrc
+    echo "login mapbox" >> ~/.netrc
+    echo "password ${MAPBOX_DOWNLOAD_TOKEN}" >> ~/.netrc
+    echo "Entry added to netrc"
+fi

--- a/Tests/Integration/test_cocoapods.sh
+++ b/Tests/Integration/test_cocoapods.sh
@@ -3,15 +3,27 @@ set -euo pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR="${DIR}/../.."
-pushd "${ROOT_DIR}/Tests/Integration/CocoaPods"
 
 if [ -z `which xcodegen` ]; then
     brew install xcodegen
 fi
 
+PODSPEC_FILE="MapboxMobileEvents.podspec"
+XCFRAMEWORK_FILE="MapboxMobileEvents.zip"
+
+pushd "${ROOT_DIR}"
+
+# Replace remote podspec source with a zip-file served locally
+LOCAL_ZIP="    :http => 'file:' + __dir__ + '\/build\/artifacts\/zip\/${XCFRAMEWORK_FILE}'"
+sed -i '' "s/.*:http.*/${LOCAL_ZIP}/g" "${ROOT_DIR}/${PODSPEC_FILE}"
+
+pushd "${ROOT_DIR}/Tests/Integration/CocoaPods"
+
 xcodegen generate
 bundle install
 bundle exec pod install
 xcodebuild -workspace PodInstall.xcworkspace -scheme PodInstall -destination 'platform=iOS Simulator,name=iPhone 11,OS=latest' build
+
+git restore "${ROOT_DIR}/${PODSPEC_FILE}"
 
 popd

--- a/scripts/deploy_ios_sdk_registry.sh
+++ b/scripts/deploy_ios_sdk_registry.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # This script deploys MapboxMobileEvents SDK for iOS to SDK Registry
-# <artifacts_dir>/MapboxMobileEvents.xcframework.zip (archive containing MapboxMobileEvents.xcframework)
-# <artifacts_dir>/MapboxMobileEvents.zip (archive containing MapboxMobileEvents.framework)
+# <artifacts_dir>/MapboxMobileEvents.zip (archive containing MapboxMobileEvents.xcframework)
+# <artifacts_dir>/MapboxMobileEvents-ios.zip (archive containing MapboxMobileEvents.framework)
 
 set -eo pipefail
 
@@ -22,8 +22,8 @@ VERSION=${VERSION_TAG#v}
 
 ARTIFACTS_DIR="$2"
 
-ZIP_XCFRAMEWORK_FILE="MapboxMobileEvents.xcframework.zip"
-ZIP_FRAMEWORK_FILE="MapboxMobileEvents.zip"
+ZIP_XCFRAMEWORK_FILE="MapboxMobileEvents.zip"
+ZIP_FRAMEWORK_FILE="MapboxMobileEvents-ios.zip"
 
 ZIP_XCFRAMEWORK="${ARTIFACTS_DIR}/${ZIP_XCFRAMEWORK_FILE}"
 ZIP_FRAMEWORK="${ARTIFACTS_DIR}/${ZIP_FRAMEWORK_FILE}"

--- a/scripts/prepare_release_artifacts.sh
+++ b/scripts/prepare_release_artifacts.sh
@@ -54,9 +54,11 @@ mkdir -p "${ROOT_DIR}/build/artifacts/zip"
 ZIPDIR="${ROOT_DIR}/build/artifacts/zip"
 
 pushd ${ROOT_DIR}/build/artifacts/frameworks/iOS.xcarchive/Products/Library/Frameworks
-zip --symlinks -r "${ZIPDIR}/MapboxMobileEvents-ios.zip" MapboxMobileEvents.framework
+cp "${ROOT_DIR}/LICENSE.md" .
+zip --symlinks -r "${ZIPDIR}/MapboxMobileEvents-ios.zip" MapboxMobileEvents.framework LICENSE.md
 popd
 
 pushd ${ROOT_DIR}/build/artifacts/frameworks
-zip --symlinks -r "${ZIPDIR}/MapboxMobileEvents.zip" MapboxMobileEvents.xcframework
+cp "${ROOT_DIR}/LICENSE.md" .
+zip --symlinks -r "${ZIPDIR}/MapboxMobileEvents.zip" MapboxMobileEvents.xcframework LICENSE.md
 popd


### PR DESCRIPTION
* LICENSE.md added to artefacts archives.
* build artefacts on git tags
* CocoaPods path should point to SDK Registry
* Package.Swift fixed to work with SDK Registry
* Integration tests fixed.