### PR TITLE
Do not start background task if telemetry collection is unnecessary

### DIFF
--- a/Sources/MapboxMobileEvents/MMEEventsManager.m
+++ b/Sources/MapboxMobileEvents/MMEEventsManager.m
@@ -173,9 +173,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)pauseOrResumeMetricsCollectionIfRequired {
     @try {
         BOOL appIsInBackground = (self.application.applicationState == UIApplicationStateBackground);
+        BOOL collectionIsEnabled = NSUserDefaults.mme_configuration.mme_isCollectionEnabled ||
+            (appIsInBackground && NSUserDefaults.mme_configuration.mme_isCollectionEnabledInBackground);
 
         // check for existing background task status, flush the event queue if needed
-        if (appIsInBackground && _backgroundTaskIdentifier == UIBackgroundTaskInvalid) {
+        if (collectionIsEnabled && appIsInBackground && _backgroundTaskIdentifier == UIBackgroundTaskInvalid) {
             MMELOG(MMELogInfo, MMEDebugEventTypeBackgroundTask, ([NSString stringWithFormat:@"Initiated background task: %@, instance: %@",@(self.backgroundTaskIdentifier),self.uniqueIdentifer.rollingInstanceIdentifer ?: @"nil"]));
             
             _backgroundTaskIdentifier = [self.application beginBackgroundTaskWithExpirationHandler:^{


### PR DESCRIPTION
Fixes #293.

The issue is easily reproducible in iOS Simulator. when app is moved to background, we start a background task, but we don't send any events and do not end the task at proper time. This PR fixes the issue by not starting a background task if telemetry collection is disabled.