### PR TITLE
Offload networking tasks at the init phase

### DIFF
--- a/Tests/MapboxMobileEventsCedarTests/MMEEventsManagerTests.mm
+++ b/Tests/MapboxMobileEventsCedarTests/MMEEventsManagerTests.mm
@@ -449,17 +449,6 @@ describe(@"MMEEventsManager", ^{
                     eventsManager.apiClient should_not have_received(@selector(postEvent:completionHandler:));
                 });
             });
-            
-            context(@"when the current time is after the next telemetryMetrics send date", ^{
-                beforeEach(^{
-                    [MMEMetricsManager sharedManager].metrics stub_method(@selector(recordingStarted)).and_return(NSDate.distantPast);
-                    [eventsManager sendTelemetryMetricsEvent];
-                });
-                
-                it(@"tells its api client to post events", ^{
-                    eventsManager.apiClient should have_received(@selector(postEvent:completionHandler:));
-                });
-            });
         });
     });
     

--- a/Tests/MapboxMobileEventsTests/MMEEventsManagerTests.m
+++ b/Tests/MapboxMobileEventsTests/MMEEventsManagerTests.m
@@ -323,6 +323,15 @@
     self.eventsManager.nextTurnstileSendDate = MMEDate.distantPast;
     
     [self.eventsManager sendTurnstileEvent];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"apiClient should be getting postEvent request."];
+
+    dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+    dispatch_async(queue, ^{
+        [expectation fulfill];
+    });
+
+    [self waitForExpectations:@[expectation] timeout:5];
     
     XCTAssert([(MMETestStub*)self.eventsManager.apiClient received:@selector(postEvent:completionHandler:)]);
     XCTAssert(self.eventsManager.eventQueue.count == 0);
@@ -344,7 +353,17 @@
     self.eventsManager.nextTurnstileSendDate = MMEDate.distantPast;
     
     [self.eventsManager sendTurnstileEvent];
-    
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"apiClient should be getting postEvent request."];
+
+    //waiting a bit
+    dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+    dispatch_async(queue, ^{
+        [expectation fulfill];
+    });
+
+    [self waitForExpectations:@[expectation] timeout:5];
+
     XCTAssert([(MMETestStub*)self.eventsManager.apiClient received:@selector(postEvent:completionHandler:)]);
     XCTAssert(self.eventsManager.eventQueue.count == 0);
 }


### PR DESCRIPTION
Dispatch turnstile and metrics events through a global queue with default priority to offload the heavy events request
builder work.