### PR TITLE
Optimize userAgentString building time

### DIFF
--- a/Tests/Integration/ensure_netrc.sh
+++ b/Tests/Integration/ensure_netrc.sh
@@ -9,5 +9,6 @@ else
     echo "machine api.mapbox.com" >> ~/.netrc
     echo "login mapbox" >> ~/.netrc
     echo "password ${MAPBOX_DOWNLOAD_TOKEN}" >> ~/.netrc
+    chmod 0600 ~/.netrc
     echo "Entry added to netrc"
 fi


### PR DESCRIPTION
Optimize `mme_userAgentString` method by:
1) Using in-memory list of loaded dylibs instead of `[NSBundle allFrameworks]` method.
2) Filtering out all out-of-bundle frameworks, since it's impossible for Mapbox Frameworks to be located anywhere else.