### PR TITLE
Make locationManager initialization thread safe

### DIFF
--- a/Sources/MapboxMobileEvents/MMEUniqueIdentifier.m
+++ b/Sources/MapboxMobileEvents/MMEUniqueIdentifier.m
@@ -2,6 +2,7 @@
 
 @interface MMEUniqueIdentifier ()
 
+@property (nonatomic, strong, readonly) NSLock *lock;
 @property (nonatomic) NSDate *instanceIDRotationDate;
 @property (nonatomic) NSString *instanceID;
 
@@ -12,11 +13,13 @@
 - (instancetype)initWithTimeInterval:(NSTimeInterval)timeInterval {
     if (self = [super init]) {
         _timeInterval = timeInterval;
+        _lock = [[NSLock alloc] init];
     }
     return self;
 }
 
 - (NSString *)rollingInstanceIdentifer {
+    [self.lock lock];
     if (self.instanceIDRotationDate && [[NSDate date] timeIntervalSinceDate:self.instanceIDRotationDate] >= 0) {
         _instanceID = nil;
     }
@@ -24,7 +27,9 @@
         _instanceID = [[NSUUID UUID] UUIDString];
         self.instanceIDRotationDate = [[NSDate date] dateByAddingTimeInterval:self.timeInterval];
     }
-    return _instanceID;
+    NSString *instanceID = _instanceID;
+    [self.lock unlock];
+    return instanceID;
 }
 
 @end


### PR DESCRIPTION
Fixes #316

There are three data-races found during running `sendTurnstileEvent` multiple times:
- `MMELocationManager`
- `MMEMetricsManager`
- `MMEUniqueIdentifier`

All these classes modify shared state which is accessed from multiple Dispatch Queue threads due to how `sendTurnstileEvent` is implemented. 

Alternative solution can be running `sendTurnstileEvent` only one at a time. 