### PR TITLE
Add info.plist key to gather telemetry in low power mode

### DIFF
--- a/Sources/MapboxMobileEvents/MMEEventsManager.m
+++ b/Sources/MapboxMobileEvents/MMEEventsManager.m
@@ -123,10 +123,12 @@ NS_ASSUME_NONNULL_BEGIN
                                                          object:nil];
 
                 if (@available(iOS 9.0, *)) {
-                    [NSNotificationCenter.defaultCenter addObserver:strongSelf
-                                                           selector:@selector(powerStateDidChange:)
-                                                               name:NSProcessInfoPowerStateDidChangeNotification
-                                                             object:nil];
+                    if (!NSUserDefaults.mme_configuration.mme_isCollectionEnabledInLowPowerMode) {
+                        [NSNotificationCenter.defaultCenter addObserver:strongSelf
+                                                               selector:@selector(powerStateDidChange:)
+                                                                   name:NSProcessInfoPowerStateDidChangeNotification
+                                                                 object:nil];
+                    }
                 }
 
                 strongSelf.paused = YES;

--- a/Sources/MapboxMobileEvents/NSUserDefaults+MMEConfiguration.m
+++ b/Sources/MapboxMobileEvents/NSUserDefaults+MMEConfiguration.m
@@ -432,7 +432,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     // if not explicitly disabled, or in simulator, check for low power mode
     if (@available(iOS 9.0, *)) {
-        if (collectionEnabled && [NSProcessInfo instancesRespondToSelector:@selector(isLowPowerModeEnabled)]) {
+        if (!self.mme_isCollectionEnabledInLowPowerMode && collectionEnabled && [NSProcessInfo instancesRespondToSelector:@selector(isLowPowerModeEnabled)]) {
                 collectionEnabled = !NSProcessInfo.processInfo.isLowPowerModeEnabled;
         }
     }
@@ -453,6 +453,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)mme_isCollectionEnabledInSimulator {
     return [self boolForKey:MMECollectionEnabledInSimulator];
+}
+
+- (BOOL)mme_isCollectionEnabledInLowPowerMode {
+    return [self boolForKey:MMECollectionEnabledInLowPowerMode];
 }
 
 // MARK: - Background Collection

--- a/Sources/MapboxMobileEvents/NSUserDefaults+MMEConfiguration_Private.h
+++ b/Sources/MapboxMobileEvents/NSUserDefaults+MMEConfiguration_Private.h
@@ -48,6 +48,7 @@ static NSString * const MMEGLMapboxAPIBaseURL = @"MGLMapboxAPIBaseURL";
 static NSString * const MMEEventsServiceURL = @"MMEEventsServiceURL";
 static NSString * const MMEConfigServiceURL = @"MMEConfigServiceURL";
 static NSString * const MMECollectionEnabledInSimulator = @"MMECollectionEnabledInSimulator";
+static NSString * const MMECollectionEnabledInLowPowerMode = @"MMECollectionEnabledInLowPowerMode";
 static NSString * const MMEDebugLogging = @"MMEDebugLogging";
 
 // MARK: - Info.plist Values

--- a/Sources/MapboxMobileEvents/include/NSUserDefaults+MMEConfiguration.h
+++ b/Sources/MapboxMobileEvents/include/NSUserDefaults+MMEConfiguration.h
@@ -74,6 +74,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// This property is volatile
 @property (nonatomic, readonly) BOOL mme_isCollectionEnabledInSimulator;
+@property (nonatomic, readonly) BOOL mme_isCollectionEnabledInLowPowerMode;
 
 // MARK: - Background Collection
 


### PR DESCRIPTION
Set `MMECollectionEnabledInLowPowerMode` to `TRUE` to continue to gather telemetry in low power mode.