### PR TITLE
Fix a possible data race in userAgentString getter

### DIFF
--- a/Tests/MapboxMobileEventsTests/NSUserDefaults+MMEConfigurationTests.m
+++ b/Tests/MapboxMobileEventsTests/NSUserDefaults+MMEConfigurationTests.m
@@ -88,6 +88,10 @@
     XCTAssert(NSUserDefaults.mme_configuration.mme_userAgentString != nil);
 }
 
+- (void)testUserAgentHasMapboxFrameworks {
+    XCTAssertTrue([NSUserDefaults.mme_configuration.mme_userAgentString containsString:@"com.mapbox.MapboxMobileEvents"]);
+}
+
 - (void)testConfigEventTagDefault {
     XCTAssert([NSUserDefaults.mme_configuration.mme_eventTag isEqual:@"tag"]);
 }


### PR DESCRIPTION
More robust solution for `userAgentString` optimization.

Previous implementation has a race condition: nullptr access could occur during dylib loading.

Fixes #327.