### PR TITLE
Check MBXBundleVersion key for a framework bundle version

### DIFF
--- a/Sources/MapboxMobileEvents/Info.plist
+++ b/Sources/MapboxMobileEvents/Info.plist
@@ -18,7 +18,7 @@
 	<string>1.0.7</string>
 	<key>CFBundleVersion</key>
 	<string>27</string>
-	<key>MGLSemanticVersionString</key>
+	<key>MBXBundleVersion</key>
 	<string>1.0.7</string>
 </dict>
 </plist>

--- a/Sources/MapboxMobileEvents/NSUserDefaults+MMEConfiguration.m
+++ b/Sources/MapboxMobileEvents/NSUserDefaults+MMEConfiguration.m
@@ -774,19 +774,20 @@ static NSBundle *MMEMainBundle = nil;
 
 // MARK: -
 
-
 - (NSString *)mme_bundleVersionString {
-    NSString *bundleVersion = @"0.0.0";
-
-    // check for MGLSemanticVersionString in Mapbox.framework
-    if ([self.infoDictionary.allKeys containsObject:@"MGLSemanticVersionString"]) {
+    NSString *bundleVersion = self.infoDictionary[@"MBXBundleVersion"];
+    if (bundleVersion == nil) {
         bundleVersion = self.infoDictionary[@"MGLSemanticVersionString"];
-        if (![bundleVersion mme_isSemverString]) { // issue a warning in debug builds
-            NSLog(@"WARNING bundle %@ MGLSemanticVersionString string (%@) is not a valid semantic version string: http://semver.org", self, bundleVersion);
-        }
     }
-    else if ([self.infoDictionary.allKeys containsObject:@"CFBundleShortVersionString"]) {
+    if (bundleVersion == nil) {
         bundleVersion = self.infoDictionary[@"CFBundleShortVersionString"];
+    }
+    if (bundleVersion == nil) {
+        bundleVersion = @"0.0.0";
+    }
+
+    if (![bundleVersion mme_isSemverString]) { // issue a warning in debug builds
+        NSLog(@"WARNING bundle %@ MGLSemanticVersionString string (%@) is not a valid semantic version string: http://semver.org", self, bundleVersion);
     }
     
     return bundleVersion;

--- a/Tests/MapboxMobileEventsTests/NSString+MMEVersions_Tests.m
+++ b/Tests/MapboxMobileEventsTests/NSString+MMEVersions_Tests.m
@@ -115,6 +115,7 @@
 - (void)test007_bundleVersionString {
     NSBundle *fakeBundle = [MMEBundleInfoFake bundleWithFakeInfo:@{@"CFBundleShortVersionString": @"1.2.3"}];
     XCTAssertTrue([fakeBundle.mme_bundleVersionString mme_isSemverString]);
+    XCTAssertEqualObjects(fakeBundle.mme_bundleVersionString, @"1.2.3");
 }
 
 - (void)test008_invalidBundleVersionString {
@@ -125,6 +126,7 @@
 - (void)test009_bundleSemanticVersionString {
     NSBundle *fakeBundle = [MMEBundleInfoFake bundleWithFakeInfo:@{@"MGLSemanticVersionString": @"1.2.3"}];
     XCTAssertTrue([fakeBundle.mme_bundleVersionString mme_isSemverString]);
+    XCTAssertEqualObjects(fakeBundle.mme_bundleVersionString, @"1.2.3");
 }
 
 - (void)test010_invalidSementicBundleVersionString {
@@ -132,7 +134,18 @@
     XCTAssertFalse([fakeBundle.mme_bundleVersionString mme_isSemverString]);
 }
 
-- (void)test011_invalidDelimitersInString {
+- (void)test011_bundleSemanticVersionString {
+    NSBundle *fakeBundle = [MMEBundleInfoFake bundleWithFakeInfo:@{@"MBXBundleVersion": @"1.2.3", @"MGLSemanticVersionString": @"0.0.1"}];
+    XCTAssertTrue([fakeBundle.mme_bundleVersionString mme_isSemverString]);
+    XCTAssertEqualObjects(fakeBundle.mme_bundleVersionString, @"1.2.3");
+}
+
+- (void)test012_invalidSementicBundleVersionString {
+    NSBundle *fakeBundle = [MMEBundleInfoFake bundleWithFakeInfo:@{@"MBXBundleVersion": @"1.2.3.4"}];
+    XCTAssertFalse([fakeBundle.mme_bundleVersionString mme_isSemverString]);
+}
+
+- (void)test013_invalidDelimitersInString {
     NSString *badString = @"user agent base(),/:;<=>?@[]{}\"\\";
     NSString *goodString = @"user agent base";
     XCTAssert([badString.mme_stringByRemovingNonUserAgentTokenCharacters
@@ -141,7 +154,7 @@
 //    com.conduent.mrparking.debug.dev/1.0-development dev-api -build 03112020 35144 PM/1 mapbox-android-location/4.5.1
 }
 
-- (void)test012_invalidUserAgent {
+- (void)test014_invalidUserAgent {
     NSString *badString = @"1.0-development (dev-api) -build 03/11/2020 3:51:44 PM";
     NSString *goodString = @"1.0-development dev-api -build 03112020 35144 PM";
     XCTAssert([badString.mme_stringByRemovingNonUserAgentTokenCharacters

--- a/scripts/update_version.sh
+++ b/scripts/update_version.sh
@@ -35,4 +35,4 @@ FRAMEWORK_PLIST=Sources/MapboxMobileEvents/Info.plist
 # remove the leading 'v' from the SEM_VERSION
 step "Adding ${SEM_VERSION:1} to ${FRAMEWORK_PLIST}"
 
-plutil -replace "MGLSemanticVersionString" -string "${SEM_VERSION:1}" "${FRAMEWORK_PLIST}"
+plutil -replace "MBXBundleVersion" -string "${SEM_VERSION:1}" "${FRAMEWORK_PLIST}"


### PR DESCRIPTION
When reporting Mapbox framework's versions MME SDK should check for recently introduced `MBXBundleVersion` first.