### PR TITLE
Construct turnstile event on background queue

### DIFF
--- a/Tests/MapboxMobileEventsTests/MMEEventsManagerTests.m
+++ b/Tests/MapboxMobileEventsTests/MMEEventsManagerTests.m
@@ -324,17 +324,15 @@
     
     [self.eventsManager sendTurnstileEvent];
 
-    XCTestExpectation *expectation = [self expectationWithDescription:@"apiClient should be getting postEvent request."];
+    NSPredicate* condition = [NSPredicate predicateWithBlock:^BOOL(id  _Nullable evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings) {
+        return [evaluatedObject received:@selector(postEvent:completionHandler:)];
+    }];
 
-    dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
-    dispatch_async(queue, ^{
-        [expectation fulfill];
-    });
-
-    [self waitForExpectations:@[expectation] timeout:5];
+    XCTestExpectation *expectation = [self expectationForPredicate:condition evaluatedWithObject:self.eventsManager.apiClient handler:^BOOL{
+        return TRUE;
+    }];
     
-    XCTAssert([(MMETestStub*)self.eventsManager.apiClient received:@selector(postEvent:completionHandler:)]);
-    XCTAssert(self.eventsManager.eventQueue.count == 0);
+    [self waitForExpectations:@[expectation] timeout:5];    XCTAssert(self.eventsManager.eventQueue.count == 0);
 }
 
 - (void)testSendsTurnstileWhenCollectionEnabled {
@@ -354,17 +352,16 @@
     
     [self.eventsManager sendTurnstileEvent];
 
-    XCTestExpectation *expectation = [self expectationWithDescription:@"apiClient should be getting postEvent request."];
+    NSPredicate* condition = [NSPredicate predicateWithBlock:^BOOL(id  _Nullable evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings) {
+        return [evaluatedObject received:@selector(postEvent:completionHandler:)];
+    }];
 
-    //waiting a bit
-    dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
-    dispatch_async(queue, ^{
-        [expectation fulfill];
-    });
-
+    XCTestExpectation *expectation = [self expectationForPredicate:condition evaluatedWithObject:self.eventsManager.apiClient handler:^BOOL{
+        return TRUE;
+    }];
+    
     [self waitForExpectations:@[expectation] timeout:5];
 
-    XCTAssert([(MMETestStub*)self.eventsManager.apiClient received:@selector(postEvent:completionHandler:)]);
     XCTAssert(self.eventsManager.eventQueue.count == 0);
 }
 


### PR DESCRIPTION
Calling CLLocationManager.locationServicesEnabled method generates a log message with the following console warning:

"/Users/distiller/project/Sources/MapboxMobileEvents/MMEEventsManager.m:356: warning run: This method can cause UI unresponsiveness if invoked on the main thread. Instead, consider waiting for the `-locationManagerDidChangeAuthorization:` callback and checking `authorizationStatus` first."

In this PR we just move the turnstile event construction to queue which already used to post events.