### PR TITLE
Fix missing location telemetry events

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,8 +5,8 @@ import PackageDescription
 import Foundation
 
 let registry = SDKRegistry()
-let version = "1.0.9"
-let checksum = "de9eec2cc077f4a9184a52fc17da485d3714394fd5ea1c1022f7b85e83ac0a89"
+let version = "1.0.8"
+let checksum = "66369bbc9474d4ed4d832e6cab6969661cd2e8a292d5196bd299cbb74cb83355"
 
 let package = Package(
     name: "MapboxMobileEvents",

--- a/Sources/MapboxMobileEvents/MMEEventsManager.m
+++ b/Sources/MapboxMobileEvents/MMEEventsManager.m
@@ -356,7 +356,7 @@ NS_ASSUME_NONNULL_BEGIN
             turnstileEventAttributes[MMEEventSDKIdentifier] = NSUserDefaults.mme_configuration.mme_legacyUserAgentBase;
             turnstileEventAttributes[MMEEventSDKVersion] = NSUserDefaults.mme_configuration.mme_legacyHostSDKVersion;
             turnstileEventAttributes[MMEEventKeyEnabledTelemetry] = @(NSUserDefaults.mme_configuration.mme_isCollectionEnabled);
-            turnstileEventAttributes[MMEEventKeyLocationEnabled] = @(CLLocationManager.locationServicesEnabled);
+            turnstileEventAttributes[MMEEventKeyLocationEnabled] = @([CLLocationManager locationServicesEnabled]);
             turnstileEventAttributes[MMEEventKeyLocationAuthorization] = [self.locationManager locationAuthorizationString];
             turnstileEventAttributes[MMEEventKeySkuId] = self.skuId ?: NSNull.null;
 
@@ -398,7 +398,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)sendPendingMetricsEvent {
     dispatch_async(_eventsDispatchQueue, ^{
         MMEEvent *pendingMetricsEvent = [MMEMetricsManager.sharedManager loadPendingTelemetryMetricsEvent];
-        
+
         if (pendingMetricsEvent) {
             [self.apiClient postEvent:pendingMetricsEvent completionHandler:^(NSError * _Nullable error) {
                 if (error) {


### PR DESCRIPTION
Due to rescheduling some telemetry event to custom dispatch queue the self.locationManager getter (that includes instantiation logic) was called on the non-main queue.
CLLocationManager requires to have NSRunLoop in the constructor thread.
Instantiation in non-main queue was an unexpected change

plus:
* minor refactoring

Fixes https://mapbox.atlassian.net/browse/CORESDK-1286