### PR TITLE
Bugfix for `This method can cause UI unresponsiveness` warning

### DIFF
--- a/Sources/MapboxMobileEvents/MMEDependencyManager.m
+++ b/Sources/MapboxMobileEvents/MMEDependencyManager.m
@@ -14,6 +14,7 @@ static MMEDependencyManager *_sharedInstance;
 }
 
 - (CLLocationManager *)locationManagerInstance {
+    NSAssert([NSThread isMainThread], @"CLLocationManager should be created only on the main thread");
     return [[CLLocationManager alloc] init];
 }
 

--- a/Sources/MapboxMobileEvents/MMELocationManager.m
+++ b/Sources/MapboxMobileEvents/MMELocationManager.m
@@ -77,9 +77,6 @@ NSString * const MMELocationManagerRegionIdentifier = @"MMELocationManagerRegion
 }
 
 - (void)startUpdatingLocation {
-    if (![CLLocationManager locationServicesEnabled]) {
-        return;
-    }
     if ([self isUpdatingLocation]) {
         return;
     }


### PR DESCRIPTION
Fixes iOS 16 SDK runtime warning `This method can cause UI unresponsiveness`. 
First fix part in https://github.com/mapbox/mapbox-events-ios/pull/344

Fixes: MAPSIOS-253
Fixes: CORESDK-1215