### PR TITLE
Bugfix/missing timer run

### DIFF
--- a/Sources/MapboxMobileEvents/MMEEventsManager.m
+++ b/Sources/MapboxMobileEvents/MMEEventsManager.m
@@ -99,6 +99,10 @@ NS_ASSUME_NONNULL_BEGIN
             self.apiClient = [[MMEAPIClient alloc] initWithAccessToken:accessToken
                                                          userAgentBase:userAgentBase
                                                         hostSDKVersion:hostSDKVersion];
+            self.timerManager = [[MMETimerManager alloc]
+                                 initWithTimeInterval:NSUserDefaults.mme_configuration.mme_eventFlushInterval
+                                 target:self
+                                 selector:@selector(flush)];
 
             __weak __typeof__(self) weakSelf = self;
             void(^initialization)(void) = ^{
@@ -134,11 +138,6 @@ NS_ASSUME_NONNULL_BEGIN
                 strongSelf.paused = YES;
                 strongSelf.locationManager.delegate = strongSelf;
                 [strongSelf resumeMetricsCollection];
-
-                strongSelf.timerManager = [[MMETimerManager alloc]
-                                           initWithTimeInterval:NSUserDefaults.mme_configuration.mme_eventFlushInterval
-                                           target:strongSelf
-                                           selector:@selector(flush)];
             };
 
             [self.dispatchManager scheduleBlock:initialization afterDelay:NSUserDefaults.mme_configuration.mme_startupDelay];
@@ -597,6 +596,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
     
     if (self.eventQueue.count == 1) {
+        NSAssert(_timerManager, @"Timer manager must exist");
         [self.timerManager start];
     }
     

--- a/Tests/MapboxMobileEventsCedarTests/MMEEventsManagerTests.mm
+++ b/Tests/MapboxMobileEventsCedarTests/MMEEventsManagerTests.mm
@@ -80,6 +80,7 @@ describe(@"MMEEventsManager", ^{
     beforeEach(^{
         dispatchManager = [[MMEDispatchManagerFake alloc] init];
         eventsManager = [MMEEventsManager.alloc initShared];
+        [eventsManager initializeWithAccessToken:@"foo" userAgentBase:@"bar" hostSDKVersion:@"baz"];
 
         eventsManager.dispatchManager = dispatchManager;
         eventsManager.locationManager = nice_fake_for(@protocol(MMELocationManager));

--- a/Tests/MapboxMobileEventsTests/MMEEventsManagerTests.m
+++ b/Tests/MapboxMobileEventsTests/MMEEventsManagerTests.m
@@ -53,6 +53,7 @@
 
 - (void)setUp {
     self.eventsManager = [MMEEventsManager.alloc initShared];
+    [self.eventsManager initializeWithAccessToken:@"" userAgentBase:@"" hostSDKVersion:@""];
     self.eventsManager.application = [[MMEUIApplicationWrapperFake alloc] init];
     
     MMECommonEventData *commonEventData = [[MMECommonEventData alloc] init];


### PR DESCRIPTION
This PR addresses the issue with missing `MMETimerManager` when the `start` is called. SDK has a lazy initialization and that's why `MMETimerManager` construction was postponed. However, if any client (like Maps SDK) will fire an event just after an object initialization it would lead to missing 180sec events flushing timer. 
The actual fix is to move `MMETimerManager` init back to the object construction. 
According to my metrics, it takes 90-100 nanoseconds to construct and has very little impact on performance.
[Instruments report with multiple runs](https://github.com/mapbox/mapbox-events-ios/files/9911030/Eager.MMETimerManager.trace.zip)

Fixes CORESDK-1430